### PR TITLE
feat: @synapse-chat/mcp — HTTP→MCP tool proxy + CLI settings helpers

### DIFF
--- a/.changeset/mcp-helper.md
+++ b/.changeset/mcp-helper.md
@@ -1,0 +1,15 @@
+---
+"@synapse-chat/mcp": minor
+"@synapse-chat/core": minor
+---
+
+feat: add `@synapse-chat/mcp` — declarative MCP tool proxies + CLI settings generators
+
+- New package `@synapse-chat/mcp` exposes a small surface for turning an application's Backend HTTP API into MCP tools that local CLI agents (Claude Code, Gemini CLI) can call directly.
+- `defineHttpTool({ name, method, path, inputSchema, confirmation? })` authoring helper with build-time validation.
+- `createMcpServer({ name, version, tools, baseUrl })` wires a set of tools into an MCP stdio server in one call (exposes the underlying `Server` handle so callers can attach custom transports / additional handlers).
+- `callHttpTool()` lower-level helper: substitutes `{placeholder}` path params, serialises remaining args as query (GET/HEAD/DELETE) or JSON body (POST/PUT/PATCH), maps 4xx/5xx responses to MCP `isError` tool results.
+- Standardised `confirmation: true` guard for destructive actions: the helper auto-injects `confirmed: boolean` into the input schema and short-circuits with an MCP error if the LLM invokes the tool without explicit confirmation.
+- Settings-file generators for Claude Code (`.mcp.json` + `.claude/settings.local.json`) and Gemini CLI (`.gemini/settings.json`). `prepareMcpWorkspace(cwd, { cli, mcpServers })` merges into existing files so user settings are preserved.
+- `deriveAllowedTools({ cli, servers })` produces CLI-specific allow-list entries (`mcp__<server>__<tool>` for Claude, `<server>__<tool>` for Gemini). Fully compatible with the existing `allowedTools` / `disallowedTools` flow in `@synapse-chat/server`.
+- `@synapse-chat/core` gains an optional `prepareWorkspace?(cwd): Promise<void>` hook on `CLIAdapter` so custom spawners can surface a uniform pre-spawn step. The built-in `ProcessManager` is unchanged; existing adapters keep working without modification.

--- a/README.md
+++ b/README.md
@@ -61,16 +61,17 @@ Each layer is independently consumable:
 | [`@synapse-chat/core`](./packages/core) | Shared types (`StreamMessage`, `ImageAttachment`, `CLIAdapter`, `SessionOptions`, `ProcessManagerLike`). Dependency-free; safe to import from any environment. |
 | [`@synapse-chat/server`](./packages/server) | Node.js `ProcessManager`, `stream-json` parser, generic `Supervisor`, and Claude / Gemini adapters. |
 | [`@synapse-chat/react`](./packages/react) | React 18/19 chat primitives (`ChatMessage`, `ToolUseGroup`, `SessionInput`), `useChat` / `useWebSocket` hooks, and a generic `WSClient`. |
+| [`@synapse-chat/mcp`](./packages/mcp) | MCP (Model Context Protocol) helpers: declarative HTTP-to-MCP tool proxies, stdio server scaffold, and Claude Code / Gemini CLI settings generators. Optional — pull in only when exposing a Backend to CLI agents. |
 
 Dependency graph:
 
 ```
 @synapse-chat/react   ──┐
-                        ├──▶  @synapse-chat/core
+@synapse-chat/mcp     ──┤──▶  @synapse-chat/core
 @synapse-chat/server  ──┘
 ```
 
-`server` and `react` never depend on each other; pick whichever subset you need.
+`server`, `react`, and `mcp` never depend on each other; pick whichever subset you need.
 
 ## Quickstart
 
@@ -144,6 +145,7 @@ export function App() {
 | Document | Topic |
 | --- | --- |
 | [docs/cli-adapter-guide.md](./docs/cli-adapter-guide.md) | Implementing a `CLIAdapter` for a new CLI (annotated `claudeAdapter` walkthrough + worked example for a hypothetical `myllm` CLI). |
+| [docs/mcp-helper-guide.md](./docs/mcp-helper-guide.md) | Exposing a Backend HTTP API to CLI agents via `@synapse-chat/mcp`: `defineHttpTool`, `createMcpServer`, settings-file generators, confirmation guard. |
 | [docs/ws-protocol.md](./docs/ws-protocol.md) | The WebSocket message protocol used by the example app. Recommended baseline for new apps; not enforced by the framework itself. |
 | [apps/example/README.md](./apps/example/README.md) | How to run the example, where to plug in your own backend, and how to add custom WS message handlers. |
 | TypeDoc API reference | Run `pnpm docs:api` from the repo root to generate HTML at `docs/api/`. The output is gitignored. |
@@ -155,7 +157,8 @@ synapse-chat/
 ├── packages/
 │   ├── core/        # @synapse-chat/core — types
 │   ├── server/      # @synapse-chat/server — ProcessManager, adapters, supervisor
-│   └── react/       # @synapse-chat/react — UI primitives + WSClient
+│   ├── react/       # @synapse-chat/react — UI primitives + WSClient
+│   └── mcp/         # @synapse-chat/mcp — MCP tool proxies + CLI settings generators
 ├── apps/
 │   └── example/     # End-to-end runnable demo (Vite + ws + claude CLI)
 ├── docs/

--- a/docs/mcp-helper-guide.md
+++ b/docs/mcp-helper-guide.md
@@ -1,0 +1,179 @@
+# MCP Helper Guide
+
+`@synapse-chat/mcp` turns an application's Backend HTTP API into MCP tools that local CLI agents (Claude Code, Gemini CLI) can call directly. It handles four things so each consumer does not reinvent them:
+
+1. Declarative tool definitions (`defineHttpTool`).
+2. An HTTP → MCP tool proxy (`createMcpServer`).
+3. A standardised `confirmation` gate for destructive operations.
+4. CLI settings-file generation (`.mcp.json`, `.claude/settings.local.json`, `.gemini/settings.json`) + derived allow-lists.
+
+The package is optional — existing `@synapse-chat/server` consumers that only need `allowedTools` / `disallowedTools` continue to work unchanged.
+
+## Why a helper?
+
+Prior to this package, every app solved the same problem differently:
+
+- **Managemaid** shipped a hand-rolled MCP stdio server and wrote `.gemini/settings.json` per worktree.
+- **vibe-admiral** called its Engine via plain HTTP from inside CLI skills and relied on `--allowedTools` to keep the model on rails.
+- New applications had no template to follow.
+
+`@synapse-chat/mcp` lets every app describe tools declaratively and share one implementation for spawning + wiring.
+
+## Anatomy of a tool
+
+```ts
+import { defineHttpTool } from "@synapse-chat/mcp";
+
+export const listDuties = defineHttpTool({
+  name: "list_duties",
+  description: "List every open duty.",
+  method: "GET",
+  path: "/api/duties",
+  inputSchema: {
+    type: "object",
+    properties: {
+      status: { type: "string", enum: ["open", "done"] },
+      limit: { type: "number" },
+    },
+  },
+});
+
+export const deleteDuty = defineHttpTool({
+  name: "delete_duty",
+  description: "Permanently delete a duty. Destructive.",
+  method: "DELETE",
+  path: "/api/duties/{id}",
+  inputSchema: {
+    type: "object",
+    properties: { id: { type: "string" } },
+    required: ["id"],
+  },
+  confirmation: true,
+});
+```
+
+### What the helper does for you
+
+- **Path placeholders**: `{id}` is extracted from the tool arguments at call time. Missing placeholders become an MCP error result so the LLM can recover.
+- **Body vs. query**: `GET` / `HEAD` / `DELETE` serialise remaining args into a query string; `POST` / `PUT` / `PATCH` serialise them as JSON body with `content-type: application/json`.
+- **Errors**: 4xx / 5xx responses are surfaced as `isError: true` tool results with `HTTP <status> <statusText>\n<body>`.
+- **Confirmation**: when `confirmation: true`, a `confirmed: boolean` property is injected into the schema and marked required. If the LLM calls the tool without `confirmed=true`, the helper returns an error result (no HTTP request is issued).
+
+## Running a server
+
+```ts
+// packages/backend/bin/mcp-server.mjs
+#!/usr/bin/env node
+import { createMcpServer } from "@synapse-chat/mcp";
+import { listDuties, deleteDuty } from "../src/mcp/tools.js";
+
+const server = createMcpServer({
+  name: "my-backend",
+  version: "0.1.0",
+  tools: [listDuties, deleteDuty],
+  baseUrl: process.env.BACKEND_BASE_URL,
+  headers: {
+    authorization: `Bearer ${process.env.BACKEND_TOKEN ?? ""}`,
+  },
+  onToolCall: ({ name, args }) => {
+    console.error(`[mcp] ${name}`, args);
+  },
+});
+
+await server.start();
+```
+
+Key points:
+
+- `start()` connects a `StdioServerTransport`. Stdio is the MVP transport; custom transports can call `server.connect(transport)` on the exposed `Server` handle directly.
+- Environment variables resolve at `start()` time — no module-load surprises.
+- Only `node` + the MCP SDK are at runtime — the helper itself has no other runtime deps.
+
+## Wiring it into a worktree
+
+```ts
+import { prepareMcpWorkspace } from "@synapse-chat/mcp";
+import { spawn } from "node:child_process";
+
+await prepareMcpWorkspace(worktreePath, {
+  cli: "claude",
+  mcpServers: {
+    "my-backend": {
+      command: "node",
+      args: ["./bin/mcp-server.mjs"],
+      env: {
+        BACKEND_BASE_URL: "http://localhost:8080",
+        BACKEND_TOKEN: process.env.BACKEND_TOKEN!,
+      },
+    },
+  },
+});
+
+spawn("claude", ["-p", "List open duties"], { cwd: worktreePath });
+```
+
+For Claude Code this writes two files:
+
+- `.mcp.json` — server spawn config.
+- `.claude/settings.local.json` — sets `enableAllProjectMcpServers: true` and adds the server to `enabledMcpjsonServers` so Claude does not prompt for approval on every launch.
+
+For `cli: "gemini"` a single `.gemini/settings.json` is written with the `mcpServers` section.
+
+Both calls preserve any unrelated fields already present in the file — safe to run on a worktree that carries user settings.
+
+## Composing with existing allowedTools
+
+`@synapse-chat/server`'s `ProcessManager` passes `--allowedTools` verbatim. Derive the MCP names and merge:
+
+```ts
+import { deriveAllowedTools } from "@synapse-chat/mcp";
+
+const mcpAllow = deriveAllowedTools({
+  cli: "claude",
+  servers: { "my-backend": [listDuties, deleteDuty] },
+});
+// → ["mcp__my-backend__list_duties", "mcp__my-backend__delete_duty"]
+
+const allowedTools = ["Read", "Glob", "Grep", ...mcpAllow];
+pm.dispatchSortie(id, cwd, prompt, "investigate");
+// or use your own spawner that respects `allowedTools`.
+```
+
+`deriveAllowedTools` emits the correct format for each CLI (`mcp__<server>__<tool>` for Claude, `<server>__<tool>` for Gemini).
+
+## Adapter integration (optional)
+
+`CLIAdapter` exposes an optional `prepareWorkspace?(cwd): Promise<void>` hook. Custom spawners that want a uniform pre-spawn step can wrap an adapter with MCP setup:
+
+```ts
+import type { CLIAdapter } from "@synapse-chat/core";
+import { prepareMcpWorkspace, type McpServersConfig } from "@synapse-chat/mcp";
+
+export function withMcp(
+  adapter: CLIAdapter,
+  opts: { cli: "claude" | "gemini"; mcpServers: McpServersConfig },
+): CLIAdapter {
+  return {
+    ...adapter,
+    async prepareWorkspace(cwd: string) {
+      await prepareMcpWorkspace(cwd, opts);
+    },
+  };
+}
+```
+
+The built-in `ProcessManager` does not invoke this hook itself — it is purely declarative metadata for custom spawners.
+
+## Testing tips
+
+- **Tools**: exercise `callHttpTool` with a fake `fetch` (see `http-client.test.ts` in this package).
+- **Server**: use `InMemoryTransport` from `@modelcontextprotocol/sdk/inMemory.js` to drive the server in-process, as done in `create-mcp-server.test.ts`.
+- **Generators**: write to a `mkdtemp` directory and assert file contents.
+
+## FAQ
+
+**Is the MCP SDK required at runtime?** Yes — `@modelcontextprotocol/sdk` is a direct dependency of `@synapse-chat/mcp`. Callers who never import from this package never pull it in.
+
+**Can I bring my own Zod?** Yes — generate a JSON Schema from Zod (e.g., `zod-to-json-schema`) and pass that as `inputSchema`. The helper does not run validation; the MCP SDK does.
+
+**When should I migrate from stub-cli / plain HTTP?** When you want the LLM to see tools as first-class function calls instead of mediating through Bash heuristics. There is no hard rule — both styles coexist.

--- a/packages/core/src/cli-adapter.ts
+++ b/packages/core/src/cli-adapter.ts
@@ -40,4 +40,16 @@ export interface CLIAdapter {
 
   /** Patterns that indicate a transient error worth retrying. */
   retryableErrorPatterns: RegExp[];
+
+  /**
+   * Optional hook invoked by the spawner before the CLI starts, to write
+   * CLI-specific config into the working directory (for example, MCP
+   * server entries into `.mcp.json` or `.gemini/settings.json`).
+   *
+   * The hook is advisory — `ProcessManager` does not call it today. It
+   * exists so that custom spawners and adapter wrappers (`withMcp(...)`,
+   * etc.) can surface a uniform pre-spawn step. Implementations should be
+   * idempotent so that repeated invocations on the same worktree are safe.
+   */
+  prepareWorkspace?(cwd: string): Promise<void>;
 }

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,83 @@
+# @synapse-chat/mcp
+
+MCP (Model Context Protocol) helpers for synapse-chat: turn an application's Backend HTTP API into a set of MCP tools that local CLI agents (Claude Code, Gemini CLI, …) can call directly.
+
+## What's inside
+
+| Export | Purpose |
+| --- | --- |
+| `defineHttpTool()` | Declarative description of a single Backend endpoint as an MCP tool. Validates name / method / path at authoring time. |
+| `createMcpServer()` | Wire a set of tool definitions into an MCP stdio server in one call. Handles `tools/list` and `tools/call` requests against the MCP SDK. |
+| `callHttpTool()` | Lower-level helper that substitutes path params, builds the request, and maps 4xx/5xx responses into MCP-shaped error results. |
+| `prepareMcpWorkspace()` | Write the CLI-specific settings files (`.mcp.json` + `.claude/settings.local.json`, or `.gemini/settings.json`) to a worktree before spawning the CLI. |
+| `generateGeminiSettings()` / `writeGeminiSettings()` | Pure / filesystem variants for Gemini CLI. |
+| `generateClaudeSettings()` / `writeClaudeSettings()` | Pure / filesystem variants for Claude Code. |
+| `deriveAllowedTools()` | Translate MCP tool definitions into a CLI allow-list (`mcp__<server>__<tool>` for Claude, `<server>__<tool>` for Gemini). |
+
+## Quick look
+
+```ts
+// packages/backend/mcp-server.mjs
+import { createMcpServer, defineHttpTool } from "@synapse-chat/mcp";
+
+const tools = [
+  defineHttpTool({
+    name: "list_duties",
+    description: "List every duty currently open.",
+    method: "GET",
+    path: "/api/duties",
+    inputSchema: {
+      type: "object",
+      properties: { status: { type: "string" } },
+    },
+  }),
+  defineHttpTool({
+    name: "delete_duty",
+    description: "Delete a duty. Destructive.",
+    method: "DELETE",
+    path: "/api/duties/{id}",
+    inputSchema: {
+      type: "object",
+      properties: { id: { type: "string" } },
+      required: ["id"],
+    },
+    confirmation: true,
+  }),
+];
+
+const server = createMcpServer({
+  name: "my-backend",
+  version: "0.1.0",
+  tools,
+  baseUrl: process.env.BACKEND_BASE_URL,
+});
+await server.start();
+```
+
+```ts
+// server.ts — spawn the CLI with the MCP server pre-wired
+import { prepareMcpWorkspace } from "@synapse-chat/mcp";
+import { spawn } from "node:child_process";
+
+await prepareMcpWorkspace(worktreePath, {
+  cli: "claude",
+  mcpServers: {
+    "my-backend": {
+      command: "node",
+      args: ["./mcp-server.mjs"],
+      env: { BACKEND_BASE_URL: "http://localhost:8080" },
+    },
+  },
+});
+
+spawn("claude", ["-p", "List open duties"], { cwd: worktreePath });
+```
+
+See [`docs/mcp-helper-guide.md`](../../docs/mcp-helper-guide.md) for the full walkthrough.
+
+## Design notes
+
+- **Input schemas are JSON Schema.** No Zod / TypeBox lock-in. The MCP SDK accepts JSON Schema verbatim, and this keeps the door open for OpenAPI → MCP generation.
+- **Confirmation is first-class.** `confirmation: true` automatically injects a required `confirmed: boolean` property into the tool's input schema and short-circuits with an MCP error if missing.
+- **Generators merge, they do not clobber.** Existing `.mcp.json` / `.gemini/settings.json` contents are preserved; only the `mcpServers` map and enablement flags are touched.
+- **Transport.** Stdio only for MVP. The server handle exposes the underlying `Server` so callers who need SSE / HTTP transports can call `server.connect(...)` with their own transport.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@synapse-chat/mcp",
+  "version": "0.0.0",
+  "description": "MCP (Model Context Protocol) helpers for synapse-chat: declarative HTTP → MCP tool proxies, stdio server scaffold, and Claude Code / Gemini CLI settings generators.",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mizunowanko/synapse-chat.git",
+    "directory": "packages/mcp"
+  },
+  "homepage": "https://github.com/mizunowanko/synapse-chat/tree/main/packages/mcp#readme",
+  "bugs": {
+    "url": "https://github.com/mizunowanko/synapse-chat/issues"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./generators": {
+      "types": "./dist/generators/index.d.ts",
+      "default": "./dist/generators/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "!src/**/*.test.ts"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "typecheck": "tsc -b",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "synapse-chat",
+    "mcp",
+    "model-context-protocol",
+    "stdio",
+    "http-proxy",
+    "cli-tool"
+  ],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@synapse-chat/core": "file:../core"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/mcp/src/confirmation.test.ts
+++ b/packages/mcp/src/confirmation.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  augmentSchemaForConfirmation,
+  checkConfirmation,
+  stripConfirmation,
+} from "./confirmation.js";
+import type { HttpToolDefinition } from "./types.js";
+
+const baseTool: HttpToolDefinition = {
+  name: "delete_thing",
+  method: "DELETE",
+  path: "/api/thing/{id}",
+  confirmation: true,
+  inputSchema: {
+    type: "object",
+    properties: { id: { type: "string" } },
+    required: ["id"],
+  },
+};
+
+describe("augmentSchemaForConfirmation", () => {
+  it("adds confirmed property and marks it required when confirmation=true", () => {
+    const schema = augmentSchemaForConfirmation(baseTool) as {
+      type: string;
+      properties: Record<string, { type: string }>;
+      required: string[];
+    };
+    expect(schema.properties.confirmed).toEqual({
+      type: "boolean",
+      description: expect.stringContaining("destructive action"),
+    });
+    expect(schema.required).toContain("confirmed");
+    expect(schema.required).toContain("id");
+  });
+
+  it("does not clobber existing properties on the schema", () => {
+    const schema = augmentSchemaForConfirmation(baseTool) as {
+      properties: Record<string, unknown>;
+    };
+    expect(schema.properties.id).toEqual({ type: "string" });
+  });
+
+  it("leaves non-confirmation tools untouched (still object-typed)", () => {
+    const schema = augmentSchemaForConfirmation({
+      ...baseTool,
+      confirmation: false,
+    }) as { type: string; properties: Record<string, unknown> };
+    expect(schema.type).toBe("object");
+    expect(schema.properties.confirmed).toBeUndefined();
+  });
+
+  it("coerces tools without inputSchema to object form", () => {
+    const tool: HttpToolDefinition = {
+      name: "ping",
+      method: "GET",
+      path: "/ping",
+    };
+    const schema = augmentSchemaForConfirmation(tool);
+    expect(schema.type).toBe("object");
+    expect(schema.properties).toEqual({});
+  });
+
+  it("does not duplicate confirmed when already required", () => {
+    const schema = augmentSchemaForConfirmation({
+      ...baseTool,
+      inputSchema: {
+        type: "object",
+        properties: { id: { type: "string" }, confirmed: { type: "boolean" } },
+        required: ["confirmed"],
+      },
+    }) as { required: string[] };
+    const confirmedCount = schema.required.filter((r) => r === "confirmed").length;
+    expect(confirmedCount).toBe(1);
+  });
+});
+
+describe("checkConfirmation", () => {
+  it("returns null when tool does not require confirmation", () => {
+    const result = checkConfirmation(
+      { ...baseTool, confirmation: false },
+      {},
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when confirmed is true", () => {
+    const result = checkConfirmation(baseTool, { id: "x", confirmed: true });
+    expect(result).toBeNull();
+  });
+
+  it("returns an isError result when confirmed is missing", () => {
+    const result = checkConfirmation(baseTool, { id: "x" });
+    expect(result).not.toBeNull();
+    expect(result!.isError).toBe(true);
+    expect(result!.content[0]!.text).toMatch(/confirmed=true/);
+  });
+
+  it("returns an isError result when confirmed is false", () => {
+    const result = checkConfirmation(baseTool, { id: "x", confirmed: false });
+    expect(result?.isError).toBe(true);
+  });
+
+  it("treats string 'true' as not confirmed (booleans only)", () => {
+    const result = checkConfirmation(baseTool, { id: "x", confirmed: "true" });
+    expect(result?.isError).toBe(true);
+  });
+});
+
+describe("stripConfirmation", () => {
+  it("removes confirmed from the args without mutating input", () => {
+    const input = { id: "x", confirmed: true };
+    const stripped = stripConfirmation(input);
+    expect(stripped).toEqual({ id: "x" });
+    expect(input).toEqual({ id: "x", confirmed: true });
+  });
+
+  it("is a no-op when confirmed is absent", () => {
+    const input = { id: "x" };
+    expect(stripConfirmation(input)).toEqual(input);
+  });
+});

--- a/packages/mcp/src/confirmation.ts
+++ b/packages/mcp/src/confirmation.ts
@@ -1,0 +1,91 @@
+import type { HttpToolDefinition, JsonSchema, ToolArgs, ToolResult } from "./types.js";
+
+const CONFIRMED_PROPERTY_DESCRIPTION =
+  "Must be set to `true` to execute this destructive action. If you invoke without confirmed=true, the tool will return an error and no HTTP request is issued.";
+
+/**
+ * Shape of the input schema after confirmation augmentation.
+ *
+ * Exported for tests and consumers that want to inspect what the MCP server
+ * will advertise to the LLM.
+ */
+export interface ConfirmationAugmentedSchema extends JsonSchema {
+  type: "object";
+  properties: Record<string, unknown>;
+  required: string[];
+}
+
+/**
+ * Return a new JSON Schema with a `confirmed: boolean` property injected and
+ * marked `required`. If the tool does not opt in to confirmation, the input
+ * schema is returned untouched (still coerced to object form for MCP).
+ */
+export function augmentSchemaForConfirmation(
+  tool: HttpToolDefinition,
+): JsonSchema {
+  const baseline: JsonSchema =
+    tool.inputSchema && typeof tool.inputSchema === "object"
+      ? { ...tool.inputSchema }
+      : { type: "object", properties: {} };
+
+  if (!tool.confirmation) {
+    if (baseline.type === undefined) baseline.type = "object";
+    if (baseline.properties === undefined) baseline.properties = {};
+    return baseline;
+  }
+
+  const properties =
+    (baseline.properties as Record<string, unknown> | undefined) ?? {};
+  const required = Array.isArray(baseline.required)
+    ? [...(baseline.required as string[])]
+    : [];
+
+  const augmented: ConfirmationAugmentedSchema = {
+    ...baseline,
+    type: "object",
+    properties: {
+      ...properties,
+      confirmed: {
+        type: "boolean",
+        description: CONFIRMED_PROPERTY_DESCRIPTION,
+      },
+    },
+    required: required.includes("confirmed") ? required : [...required, "confirmed"],
+  };
+
+  return augmented;
+}
+
+/**
+ * If the tool requires confirmation and the incoming args do not carry
+ * `confirmed: true`, short-circuit with an MCP error response.
+ *
+ * Returns `null` when the call is allowed to proceed. Callers should pass
+ * through to the underlying HTTP client on `null`.
+ */
+export function checkConfirmation(
+  tool: HttpToolDefinition,
+  args: ToolArgs,
+): ToolResult | null {
+  if (!tool.confirmation) return null;
+  if (args.confirmed === true) return null;
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: `Tool "${tool.name}" requires explicit confirmation. Re-invoke with confirmed=true (as a boolean, not a string) to proceed.`,
+      },
+    ],
+  };
+}
+
+/**
+ * Strip the helper-managed `confirmed` flag from the args bag before it is
+ * forwarded to the HTTP layer. Returns a new object so callers never mutate
+ * the original.
+ */
+export function stripConfirmation(args: ToolArgs): ToolArgs {
+  const { confirmed: _ignored, ...rest } = args;
+  return rest;
+}

--- a/packages/mcp/src/create-mcp-server.test.ts
+++ b/packages/mcp/src/create-mcp-server.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMcpServer } from "./create-mcp-server.js";
+import { defineHttpTool } from "./define-http-tool.js";
+import type { FetchLike } from "./http-client.js";
+import type { HttpToolDefinition } from "./types.js";
+
+function stubFetch(
+  impl: (url: string, init?: Parameters<FetchLike>[1]) => {
+    ok: boolean;
+    status: number;
+    statusText: string;
+    body: string;
+  },
+): FetchLike {
+  return async (url, init) => {
+    const result = impl(url, init);
+    return {
+      ok: result.ok,
+      status: result.status,
+      statusText: result.statusText,
+      text: async () => result.body,
+    };
+  };
+}
+
+async function connect(tools: HttpToolDefinition[], overrides: {
+  fetch?: FetchLike;
+  baseUrl?: string;
+  onToolCall?: (event: { name: string; args: Record<string, unknown> }) => void;
+} = {}): Promise<{ client: Client; close: () => Promise<void> }> {
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const handle = createMcpServer({
+    name: "test-server",
+    version: "0.0.0",
+    tools,
+    baseUrl: overrides.baseUrl ?? "http://backend.test",
+    ...(overrides.fetch ? { fetch: overrides.fetch } : {}),
+    ...(overrides.onToolCall ? { onToolCall: overrides.onToolCall } : {}),
+  });
+  await handle.server.connect(serverTransport);
+
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    async close() {
+      await client.close();
+      await handle.stop();
+    },
+  };
+}
+
+describe("createMcpServer — tools/list", () => {
+  it("advertises every registered tool", async () => {
+    const tools = [
+      defineHttpTool({
+        name: "list_items",
+        description: "List items",
+        method: "GET",
+        path: "/api/items",
+      }),
+      defineHttpTool({
+        name: "delete_item",
+        method: "DELETE",
+        path: "/api/items/{id}",
+        confirmation: true,
+      }),
+    ];
+    const { client, close } = await connect(tools);
+    try {
+      const { tools: advertised } = await client.listTools();
+      expect(advertised).toHaveLength(2);
+      const names = advertised.map((t) => t.name).sort();
+      expect(names).toEqual(["delete_item", "list_items"]);
+      const del = advertised.find((t) => t.name === "delete_item")!;
+      const delSchema = del.inputSchema as {
+        properties: Record<string, unknown>;
+        required?: string[];
+      };
+      expect(delSchema.properties.confirmed).toBeDefined();
+      expect(delSchema.required).toContain("confirmed");
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe("createMcpServer — tools/call", () => {
+  it("proxies a GET tool call through the injected fetch", async () => {
+    const fetchMock = vi.fn(
+      stubFetch(() => ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: '{"count":3}',
+      })),
+    );
+    const tools = [
+      defineHttpTool({
+        name: "list_items",
+        method: "GET",
+        path: "/api/items",
+      }),
+    ];
+    const { client, close } = await connect(tools, { fetch: fetchMock });
+    try {
+      const result = await client.callTool({
+        name: "list_items",
+        arguments: { limit: 2 },
+      });
+      expect(result.isError).toBeFalsy();
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content[0]!.text).toBe('{"count":3}');
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const firstCallArgs = fetchMock.mock.calls[0]!;
+      expect(firstCallArgs[0]).toBe("http://backend.test/api/items?limit=2");
+    } finally {
+      await close();
+    }
+  });
+
+  it("short-circuits confirmation-required tools without confirmed=true", async () => {
+    const fetchMock = vi.fn(
+      stubFetch(() => ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: "{}",
+      })),
+    );
+    const tools = [
+      defineHttpTool({
+        name: "delete_item",
+        method: "DELETE",
+        path: "/api/items/{id}",
+        confirmation: true,
+      }),
+    ];
+    const { client, close } = await connect(tools, { fetch: fetchMock });
+    try {
+      const result = await client.callTool({
+        name: "delete_item",
+        arguments: { id: "abc" },
+      });
+      expect(result.isError).toBe(true);
+      const content = result.content as Array<{ text: string }>;
+      expect(content[0]!.text).toMatch(/confirmed=true/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      await close();
+    }
+  });
+
+  it("executes confirmation-required tools when confirmed=true", async () => {
+    const fetchMock = vi.fn(
+      stubFetch(() => ({
+        ok: true,
+        status: 204,
+        statusText: "No Content",
+        body: "",
+      })),
+    );
+    const tools = [
+      defineHttpTool({
+        name: "delete_item",
+        method: "DELETE",
+        path: "/api/items/{id}",
+        confirmation: true,
+      }),
+    ];
+    const { client, close } = await connect(tools, { fetch: fetchMock });
+    try {
+      const result = await client.callTool({
+        name: "delete_item",
+        arguments: { id: "abc", confirmed: true },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const firstCallArgs = fetchMock.mock.calls[0]!;
+      expect(firstCallArgs[0]).toBe("http://backend.test/api/items/abc");
+      expect(firstCallArgs[1]?.method).toBe("DELETE");
+      expect(firstCallArgs[1]?.body).toBeUndefined();
+    } finally {
+      await close();
+    }
+  });
+
+  it("returns isError tool result for unknown tool names", async () => {
+    const tools = [
+      defineHttpTool({
+        name: "known",
+        method: "GET",
+        path: "/",
+      }),
+    ];
+    const { client, close } = await connect(tools, {
+      fetch: stubFetch(() => ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: "",
+      })),
+    });
+    try {
+      const result = await client.callTool({
+        name: "unknown",
+        arguments: {},
+      });
+      expect(result.isError).toBe(true);
+    } finally {
+      await close();
+    }
+  });
+
+  it("fires onToolCall hook for every invocation", async () => {
+    const events: Array<{ name: string; args: Record<string, unknown> }> = [];
+    const tools = [
+      defineHttpTool({
+        name: "ping",
+        method: "GET",
+        path: "/",
+      }),
+    ];
+    const { client, close } = await connect(tools, {
+      fetch: stubFetch(() => ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: "ok",
+      })),
+      onToolCall: (e) => events.push(e),
+    });
+    try {
+      await client.callTool({ name: "ping", arguments: { q: "1" } });
+      expect(events).toEqual([{ name: "ping", args: { q: "1" } }]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("rejects duplicate tool names at construction time", () => {
+    expect(() =>
+      createMcpServer({
+        name: "dup",
+        version: "0",
+        tools: [
+          { name: "same", method: "GET", path: "/a" },
+          { name: "same", method: "GET", path: "/b" },
+        ],
+      }),
+    ).toThrow(/duplicate tool name/);
+  });
+});

--- a/packages/mcp/src/create-mcp-server.ts
+++ b/packages/mcp/src/create-mcp-server.ts
@@ -1,0 +1,174 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolResult,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  augmentSchemaForConfirmation,
+  checkConfirmation,
+  stripConfirmation,
+} from "./confirmation.js";
+import { callHttpTool, type FetchLike } from "./http-client.js";
+import type {
+  HttpToolDefinition,
+  ToolArgs,
+  ToolResult,
+} from "./types.js";
+
+/** Options passed to {@link createMcpServer}. */
+export interface CreateMcpServerOptions {
+  /** MCP server name advertised over the protocol. */
+  readonly name: string;
+
+  /** Server version advertised over the protocol. */
+  readonly version: string;
+
+  /** Tools the server will expose. Must have unique names. */
+  readonly tools: readonly HttpToolDefinition[];
+
+  /**
+   * Base URL of the Backend HTTP API the tools proxy to. If omitted, the
+   * value is read from `process.env.SYNAPSE_MCP_BASE_URL` at server start.
+   * If neither is available, the server throws on first tool invocation.
+   */
+  readonly baseUrl?: string;
+
+  /** Additional HTTP headers applied to every tool call. */
+  readonly headers?: Record<string, string>;
+
+  /** Optional custom fetch implementation (defaults to `globalThis.fetch`). */
+  readonly fetch?: FetchLike;
+
+  /**
+   * Hook invoked when a tool is called. Useful for logging. Does not affect
+   * the tool result.
+   */
+  readonly onToolCall?: (event: { name: string; args: ToolArgs }) => void;
+}
+
+/** Handle returned from {@link createMcpServer}. */
+export interface McpServerHandle {
+  /** Connect the server to a stdio transport and start serving requests. */
+  start(): Promise<void>;
+
+  /** Close the transport and release resources. */
+  stop(): Promise<void>;
+
+  /**
+   * Low-level access to the underlying MCP server instance. Escape hatch
+   * for callers that want to register additional request handlers.
+   */
+  readonly server: Server;
+}
+
+function assertUniqueToolNames(tools: readonly HttpToolDefinition[]): void {
+  const seen = new Set<string>();
+  for (const tool of tools) {
+    if (seen.has(tool.name)) {
+      throw new Error(
+        `createMcpServer: duplicate tool name "${tool.name}". Each tool must have a unique name within one server.`,
+      );
+    }
+    seen.add(tool.name);
+  }
+}
+
+/**
+ * Build an MCP stdio server from a set of declarative HTTP tool definitions.
+ *
+ * The returned handle is idle until {@link McpServerHandle.start} is
+ * invoked. `start()` connects a {@link StdioServerTransport} and begins
+ * responding to `tools/list` and `tools/call` requests.
+ */
+export function createMcpServer(options: CreateMcpServerOptions): McpServerHandle {
+  const { name, version, tools, headers, fetch: fetchImpl, onToolCall } = options;
+  assertUniqueToolNames(tools);
+
+  const server = new Server(
+    { name, version },
+    { capabilities: { tools: {} } },
+  );
+
+  const toolsByName = new Map<string, HttpToolDefinition>();
+  for (const tool of tools) toolsByName.set(tool.name, tool);
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: tools.map((tool) => {
+      const descriptor: {
+        name: string;
+        description?: string;
+        inputSchema: Record<string, unknown>;
+      } = {
+        name: tool.name,
+        inputSchema: augmentSchemaForConfirmation(tool) as Record<string, unknown>,
+      };
+      if (tool.description) descriptor.description = tool.description;
+      return descriptor;
+    }),
+  }));
+
+  server.setRequestHandler(
+    CallToolRequestSchema,
+    async (request): Promise<CallToolResult> => {
+      const { name: toolName, arguments: rawArgs } = request.params;
+      const tool = toolsByName.get(toolName);
+      if (!tool) {
+        const errorResult: ToolResult = {
+          isError: true,
+          content: [{ type: "text", text: `Unknown tool "${toolName}"` }],
+        };
+        return errorResult as CallToolResult;
+      }
+
+      const args: ToolArgs =
+        rawArgs && typeof rawArgs === "object" && !Array.isArray(rawArgs)
+          ? { ...(rawArgs as ToolArgs) }
+          : {};
+
+      onToolCall?.({ name: tool.name, args });
+
+      const confirmationError = checkConfirmation(tool, args);
+      if (confirmationError) return confirmationError as CallToolResult;
+
+      const baseUrl = options.baseUrl ?? process.env.SYNAPSE_MCP_BASE_URL;
+      if (!baseUrl) {
+        const errorResult: ToolResult = {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Tool "${tool.name}" cannot run: no baseUrl configured. Pass \`baseUrl\` to createMcpServer() or set SYNAPSE_MCP_BASE_URL.`,
+            },
+          ],
+        };
+        return errorResult as CallToolResult;
+      }
+
+      const callOptions: Parameters<typeof callHttpTool>[0] = {
+        tool,
+        args: stripConfirmation(args),
+        baseUrl,
+      };
+      if (headers !== undefined) callOptions.headers = headers;
+      if (fetchImpl !== undefined) callOptions.fetch = fetchImpl;
+      const result = await callHttpTool(callOptions);
+      return result as CallToolResult;
+    },
+  );
+
+  let transport: StdioServerTransport | undefined;
+
+  return {
+    server,
+    async start() {
+      transport = new StdioServerTransport();
+      await server.connect(transport);
+    },
+    async stop() {
+      await server.close();
+      transport = undefined;
+    },
+  };
+}

--- a/packages/mcp/src/define-http-tool.test.ts
+++ b/packages/mcp/src/define-http-tool.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { defineHttpTool } from "./define-http-tool.js";
+
+describe("defineHttpTool", () => {
+  it("returns the input definition unchanged when valid", () => {
+    const tool = defineHttpTool({
+      name: "list_duties",
+      description: "List all duties",
+      method: "GET",
+      path: "/api/duties",
+    });
+    expect(tool.name).toBe("list_duties");
+    expect(tool.method).toBe("GET");
+    expect(tool.description).toBe("List all duties");
+  });
+
+  it("accepts tool names starting with underscore", () => {
+    const tool = defineHttpTool({
+      name: "_internal_ping",
+      method: "GET",
+      path: "/_ping",
+    });
+    expect(tool.name).toBe("_internal_ping");
+  });
+
+  it("accepts hyphens and digits in tool names", () => {
+    const tool = defineHttpTool({
+      name: "get-user-v2",
+      method: "GET",
+      path: "/api/v2/user",
+    });
+    expect(tool.name).toBe("get-user-v2");
+  });
+
+  it("rejects tool names starting with a digit", () => {
+    expect(() =>
+      defineHttpTool({
+        name: "1bad",
+        method: "GET",
+        path: "/x",
+      } as never),
+    ).toThrow(/invalid tool name/);
+  });
+
+  it("rejects empty name", () => {
+    expect(() =>
+      defineHttpTool({ name: "", method: "GET", path: "/x" } as never),
+    ).toThrow();
+  });
+
+  it("rejects missing method", () => {
+    expect(() =>
+      defineHttpTool({ name: "x", path: "/y" } as never),
+    ).toThrow(/method.*required/);
+  });
+
+  it("rejects paths without a leading slash", () => {
+    expect(() =>
+      defineHttpTool({ name: "bad", method: "GET", path: "api/x" } as never),
+    ).toThrow(/must start with "\/"/);
+  });
+
+  it("preserves confirmation flag on returned definition", () => {
+    const tool = defineHttpTool({
+      name: "delete_thing",
+      method: "DELETE",
+      path: "/api/thing/{id}",
+      confirmation: true,
+    });
+    expect(tool.confirmation).toBe(true);
+  });
+});

--- a/packages/mcp/src/define-http-tool.ts
+++ b/packages/mcp/src/define-http-tool.ts
@@ -1,0 +1,36 @@
+import type { HttpToolDefinition } from "./types.js";
+
+const TOOL_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+
+/**
+ * Identity helper for declaring an HTTP-backed MCP tool.
+ *
+ * Returns the same object back so that tool registries can be written as
+ * `const tools = [defineHttpTool({...}), defineHttpTool({...})];`. The helper
+ * validates the definition at author time so mistakes surface during module
+ * load rather than at first invocation.
+ */
+export function defineHttpTool<T extends HttpToolDefinition>(def: T): T {
+  if (!def.name || typeof def.name !== "string") {
+    throw new Error("defineHttpTool: `name` is required and must be a string");
+  }
+  if (!TOOL_NAME_PATTERN.test(def.name)) {
+    throw new Error(
+      `defineHttpTool: invalid tool name \`${def.name}\`. Allowed characters: A-Z, a-z, 0-9, underscore, hyphen; must start with a letter or underscore.`,
+    );
+  }
+  if (!def.method) {
+    throw new Error(`defineHttpTool(${def.name}): \`method\` is required`);
+  }
+  if (!def.path || typeof def.path !== "string") {
+    throw new Error(
+      `defineHttpTool(${def.name}): \`path\` is required and must be a string`,
+    );
+  }
+  if (!def.path.startsWith("/")) {
+    throw new Error(
+      `defineHttpTool(${def.name}): \`path\` must start with "/" (got "${def.path}")`,
+    );
+  }
+  return def;
+}

--- a/packages/mcp/src/generators/allowed-tools.test.ts
+++ b/packages/mcp/src/generators/allowed-tools.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveAllowedTools,
+  formatMcpToolName,
+} from "./allowed-tools.js";
+import { defineHttpTool } from "../define-http-tool.js";
+
+describe("formatMcpToolName", () => {
+  it("prefixes with mcp__ for Claude", () => {
+    expect(formatMcpToolName("claude", "my-backend", "list_items")).toBe(
+      "mcp__my-backend__list_items",
+    );
+  });
+
+  it("omits the mcp__ prefix for Gemini", () => {
+    expect(formatMcpToolName("gemini", "my-backend", "list_items")).toBe(
+      "my-backend__list_items",
+    );
+  });
+});
+
+describe("deriveAllowedTools", () => {
+  const tools = [
+    defineHttpTool({ name: "list_items", method: "GET", path: "/items" }),
+    defineHttpTool({ name: "create_item", method: "POST", path: "/items" }),
+  ];
+
+  it("produces the Claude allow-list format", () => {
+    const names = deriveAllowedTools({
+      cli: "claude",
+      servers: { backend: tools },
+    });
+    expect(names).toEqual([
+      "mcp__backend__list_items",
+      "mcp__backend__create_item",
+    ]);
+  });
+
+  it("produces the Gemini allow-list format", () => {
+    const names = deriveAllowedTools({
+      cli: "gemini",
+      servers: { backend: tools },
+    });
+    expect(names).toEqual(["backend__list_items", "backend__create_item"]);
+  });
+
+  it("handles multiple servers", () => {
+    const names = deriveAllowedTools({
+      cli: "claude",
+      servers: {
+        a: [defineHttpTool({ name: "ping", method: "GET", path: "/" })],
+        b: [defineHttpTool({ name: "pong", method: "GET", path: "/" })],
+      },
+    });
+    expect(names).toEqual(["mcp__a__ping", "mcp__b__pong"]);
+  });
+});

--- a/packages/mcp/src/generators/allowed-tools.ts
+++ b/packages/mcp/src/generators/allowed-tools.ts
@@ -1,0 +1,42 @@
+import type { CliTarget, HttpToolDefinition } from "../types.js";
+
+/** Map of MCP server name → tools exposed by that server. */
+export type ToolsByServer = Record<string, readonly HttpToolDefinition[]>;
+
+export interface DeriveAllowedToolsOptions {
+  /** CLI that will read the allow-list. Determines the name format. */
+  cli: CliTarget;
+  /** Server name → list of tool definitions advertised by that server. */
+  servers: ToolsByServer;
+}
+
+/**
+ * Format a single MCP tool name for the given CLI.
+ *
+ * - Claude Code expects `mcp__<server>__<tool>`.
+ * - Gemini CLI expects `<server>__<tool>` (no `mcp__` prefix).
+ */
+export function formatMcpToolName(
+  cli: CliTarget,
+  serverName: string,
+  toolName: string,
+): string {
+  if (cli === "claude") return `mcp__${serverName}__${toolName}`;
+  return `${serverName}__${toolName}`;
+}
+
+/**
+ * Derive the list of CLI allowed-tool names from a mapping of MCP servers to
+ * their tool definitions. Existing allow-lists can `concat()` the result to
+ * add MCP tools without losing baseline permissions.
+ */
+export function deriveAllowedTools(options: DeriveAllowedToolsOptions): string[] {
+  const { cli, servers } = options;
+  const names: string[] = [];
+  for (const [serverName, tools] of Object.entries(servers)) {
+    for (const tool of tools) {
+      names.push(formatMcpToolName(cli, serverName, tool.name));
+    }
+  }
+  return names;
+}

--- a/packages/mcp/src/generators/claude-settings.test.ts
+++ b/packages/mcp/src/generators/claude-settings.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  generateClaudeSettings,
+  writeClaudeSettings,
+} from "./claude-settings.js";
+
+describe("generateClaudeSettings", () => {
+  it("produces mcpJson with the server entries and local settings that enable them", () => {
+    const { mcpJson, localSettings } = generateClaudeSettings({
+      "my-backend": { command: "node", args: ["./server.mjs"] },
+    });
+    expect(mcpJson.mcpServers).toEqual({
+      "my-backend": { command: "node", args: ["./server.mjs"] },
+    });
+    expect(localSettings.enableAllProjectMcpServers).toBe(true);
+    expect(localSettings.enabledMcpjsonServers).toContain("my-backend");
+  });
+
+  it("merges with existing mcpJson and keeps existing servers", () => {
+    const { mcpJson, localSettings } = generateClaudeSettings(
+      { "new-one": { command: "node" } },
+      {
+        mcpJson: {
+          mcpServers: {
+            keep: { command: "x" },
+          },
+          customField: "preserved",
+        },
+        localSettings: {
+          enabledMcpjsonServers: ["keep"],
+          unrelated: "leave-alone",
+        },
+      },
+    );
+    expect(mcpJson.mcpServers).toEqual({
+      keep: { command: "x" },
+      "new-one": { command: "node" },
+    });
+    expect(mcpJson.customField).toBe("preserved");
+    expect(localSettings.enabledMcpjsonServers).toEqual(
+      expect.arrayContaining(["keep", "new-one"]),
+    );
+    expect(localSettings.unrelated).toBe("leave-alone");
+  });
+
+  it("does not duplicate existing server names in enabledMcpjsonServers", () => {
+    const { localSettings } = generateClaudeSettings(
+      { "my-backend": { command: "node" } },
+      {
+        localSettings: { enabledMcpjsonServers: ["my-backend"] },
+      },
+    );
+    const count = (localSettings.enabledMcpjsonServers ?? []).filter(
+      (n) => n === "my-backend",
+    ).length;
+    expect(count).toBe(1);
+  });
+});
+
+describe("writeClaudeSettings", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "claude-settings-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes .mcp.json and .claude/settings.local.json when absent", async () => {
+    const { mcpJsonPath, localSettingsPath } = await writeClaudeSettings(dir, {
+      "my-backend": { command: "node", args: ["./s.mjs"] },
+    });
+    expect(mcpJsonPath).toBe(join(dir, ".mcp.json"));
+    expect(localSettingsPath).toBe(join(dir, ".claude", "settings.local.json"));
+
+    const mcpJson = JSON.parse(await readFile(mcpJsonPath, "utf8"));
+    expect(mcpJson.mcpServers["my-backend"]).toEqual({
+      command: "node",
+      args: ["./s.mjs"],
+    });
+
+    const local = JSON.parse(await readFile(localSettingsPath, "utf8"));
+    expect(local.enableAllProjectMcpServers).toBe(true);
+    expect(local.enabledMcpjsonServers).toContain("my-backend");
+  });
+
+  it("merges with existing files and preserves unrelated keys", async () => {
+    const mcpPath = join(dir, ".mcp.json");
+    const localPath = join(dir, ".claude", "settings.local.json");
+    await writeFile(
+      mcpPath,
+      JSON.stringify({
+        mcpServers: { keep: { command: "x" } },
+        version: 1,
+      }),
+      "utf8",
+    );
+    await mkdir(join(dir, ".claude"), { recursive: true });
+    await writeFile(
+      localPath,
+      JSON.stringify({
+        enabledMcpjsonServers: ["keep"],
+        someUserPref: "yes",
+      }),
+      "utf8",
+    );
+
+    await writeClaudeSettings(dir, { "new-one": { command: "node" } });
+
+    const mcp = JSON.parse(await readFile(mcpPath, "utf8"));
+    expect(mcp.mcpServers).toEqual({
+      keep: { command: "x" },
+      "new-one": { command: "node" },
+    });
+    expect(mcp.version).toBe(1);
+
+    const local = JSON.parse(await readFile(localPath, "utf8"));
+    expect(local.someUserPref).toBe("yes");
+    expect(local.enableAllProjectMcpServers).toBe(true);
+    expect(local.enabledMcpjsonServers).toEqual(
+      expect.arrayContaining(["keep", "new-one"]),
+    );
+  });
+});

--- a/packages/mcp/src/generators/claude-settings.ts
+++ b/packages/mcp/src/generators/claude-settings.ts
@@ -1,0 +1,112 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { McpServersConfig } from "../types.js";
+
+/** Shape of `.mcp.json` we write or merge into. */
+export interface ClaudeMcpJson {
+  mcpServers?: McpServersConfig;
+  [key: string]: unknown;
+}
+
+/** Relevant subset of `.claude/settings.local.json`. */
+export interface ClaudeLocalSettings {
+  enableAllProjectMcpServers?: boolean;
+  enabledMcpjsonServers?: string[];
+  [key: string]: unknown;
+}
+
+export interface ClaudeSettings {
+  mcpJson: ClaudeMcpJson;
+  localSettings: ClaudeLocalSettings;
+}
+
+/**
+ * Build the Claude Code settings payloads for a set of MCP servers.
+ *
+ * - `.mcp.json` gets an entry per server (merged with any existing entries).
+ * - `.claude/settings.local.json` sets `enableAllProjectMcpServers: true`
+ *   and adds each server to `enabledMcpjsonServers` so Claude Code does not
+ *   prompt for approval on every launch.
+ */
+export function generateClaudeSettings(
+  mcpServers: McpServersConfig,
+  existing?: { mcpJson?: ClaudeMcpJson; localSettings?: ClaudeLocalSettings },
+): ClaudeSettings {
+  const baseMcp = existing?.mcpJson ? { ...existing.mcpJson } : {};
+  const mergedServers: McpServersConfig = {
+    ...(baseMcp.mcpServers ?? {}),
+    ...mcpServers,
+  };
+  const mcpJson: ClaudeMcpJson = { ...baseMcp, mcpServers: mergedServers };
+
+  const baseLocal: ClaudeLocalSettings = existing?.localSettings
+    ? { ...existing.localSettings }
+    : {};
+  const previouslyEnabled = Array.isArray(baseLocal.enabledMcpjsonServers)
+    ? baseLocal.enabledMcpjsonServers
+    : [];
+  const enabledSet = new Set<string>([
+    ...previouslyEnabled,
+    ...Object.keys(mcpServers),
+  ]);
+
+  const localSettings: ClaudeLocalSettings = {
+    ...baseLocal,
+    enableAllProjectMcpServers: true,
+    enabledMcpjsonServers: Array.from(enabledSet),
+  };
+
+  return { mcpJson, localSettings };
+}
+
+/**
+ * Write both `.mcp.json` (at `cwd`) and `.claude/settings.local.json` with
+ * the given MCP servers merged into any existing config. Returns the paths
+ * that were written.
+ */
+export async function writeClaudeSettings(
+  cwd: string,
+  mcpServers: McpServersConfig,
+): Promise<{ mcpJsonPath: string; localSettingsPath: string }> {
+  const mcpJsonPath = join(cwd, ".mcp.json");
+  const localSettingsPath = join(cwd, ".claude", "settings.local.json");
+
+  const existingMcp = await readJsonIfExists<ClaudeMcpJson>(mcpJsonPath);
+  const existingLocal = await readJsonIfExists<ClaudeLocalSettings>(localSettingsPath);
+
+  const existing: {
+    mcpJson?: ClaudeMcpJson;
+    localSettings?: ClaudeLocalSettings;
+  } = {};
+  if (existingMcp) existing.mcpJson = existingMcp;
+  if (existingLocal) existing.localSettings = existingLocal;
+
+  const { mcpJson, localSettings } = generateClaudeSettings(mcpServers, existing);
+
+  await mkdir(dirname(mcpJsonPath), { recursive: true });
+  await writeFile(mcpJsonPath, `${JSON.stringify(mcpJson, null, 2)}\n`, "utf8");
+  await mkdir(dirname(localSettingsPath), { recursive: true });
+  await writeFile(
+    localSettingsPath,
+    `${JSON.stringify(localSettings, null, 2)}\n`,
+    "utf8",
+  );
+
+  return { mcpJsonPath, localSettingsPath };
+}
+
+async function readJsonIfExists<T extends object>(
+  filePath: string,
+): Promise<T | null> {
+  try {
+    const text = await readFile(filePath, "utf8");
+    const parsed = JSON.parse(text) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as T;
+    }
+    return null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}

--- a/packages/mcp/src/generators/gemini-settings.test.ts
+++ b/packages/mcp/src/generators/gemini-settings.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  generateGeminiSettings,
+  writeGeminiSettings,
+} from "./gemini-settings.js";
+
+describe("generateGeminiSettings", () => {
+  it("produces a settings payload with the mcpServers map", () => {
+    const settings = generateGeminiSettings({
+      "my-backend": { command: "node", args: ["./server.mjs"] },
+    });
+    expect(settings).toEqual({
+      mcpServers: {
+        "my-backend": { command: "node", args: ["./server.mjs"] },
+      },
+    });
+  });
+
+  it("merges new servers over existing entries without losing others", () => {
+    const settings = generateGeminiSettings(
+      { "new-one": { command: "node", args: ["./new.mjs"] } },
+      {
+        theme: "dark",
+        mcpServers: {
+          "keep-me": { command: "node", args: ["./keep.mjs"] },
+          "new-one": { command: "node", args: ["./OLD.mjs"] },
+        },
+      },
+    );
+    expect(settings.theme).toBe("dark");
+    expect(settings.mcpServers).toEqual({
+      "keep-me": { command: "node", args: ["./keep.mjs"] },
+      "new-one": { command: "node", args: ["./new.mjs"] },
+    });
+  });
+});
+
+describe("writeGeminiSettings", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "gemini-settings-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes .gemini/settings.json when none exists", async () => {
+    const path = await writeGeminiSettings(dir, {
+      "my-backend": { command: "node", args: ["./s.mjs"] },
+    });
+    const text = await readFile(path, "utf8");
+    const parsed = JSON.parse(text);
+    expect(parsed).toEqual({
+      mcpServers: { "my-backend": { command: "node", args: ["./s.mjs"] } },
+    });
+    expect(text.endsWith("\n")).toBe(true);
+  });
+
+  it("merges with existing settings.json and preserves unrelated keys", async () => {
+    const settingsPath = join(dir, ".gemini", "settings.json");
+    await mkdir(join(dir, ".gemini"), { recursive: true });
+    await writeFile(
+      settingsPath,
+      JSON.stringify({ theme: "light", mcpServers: { keep: { command: "x" } } }),
+      "utf8",
+    );
+    await writeGeminiSettings(dir, {
+      "new-one": { command: "node" },
+    });
+    const parsed = JSON.parse(await readFile(settingsPath, "utf8"));
+    expect(parsed.theme).toBe("light");
+    expect(parsed.mcpServers).toEqual({
+      keep: { command: "x" },
+      "new-one": { command: "node" },
+    });
+  });
+});

--- a/packages/mcp/src/generators/gemini-settings.ts
+++ b/packages/mcp/src/generators/gemini-settings.ts
@@ -1,0 +1,60 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { McpServersConfig } from "../types.js";
+
+/** Shape of `.gemini/settings.json` we write or merge into. */
+export interface GeminiSettings {
+  mcpServers?: McpServersConfig;
+  [key: string]: unknown;
+}
+
+/**
+ * Build the Gemini-CLI `settings.json` payload for a set of MCP servers.
+ *
+ * If `existing` is passed, its `mcpServers` map is shallow-merged with the
+ * provided definitions (new entries win) and every other top-level field is
+ * preserved verbatim.
+ */
+export function generateGeminiSettings(
+  mcpServers: McpServersConfig,
+  existing?: GeminiSettings,
+): GeminiSettings {
+  const base = existing ? { ...existing } : {};
+  const merged: McpServersConfig = {
+    ...(base.mcpServers ?? {}),
+    ...mcpServers,
+  };
+  return { ...base, mcpServers: merged };
+}
+
+/**
+ * Write `<cwd>/.gemini/settings.json` with the given MCP servers merged in.
+ * Creates the parent directory if missing. Existing fields in the settings
+ * file are preserved.
+ */
+export async function writeGeminiSettings(
+  cwd: string,
+  mcpServers: McpServersConfig,
+): Promise<string> {
+  const dir = join(cwd, ".gemini");
+  const filePath = join(dir, "settings.json");
+  const existing = await readJsonIfExists(filePath);
+  const payload = generateGeminiSettings(mcpServers, existing ?? undefined);
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  return filePath;
+}
+
+async function readJsonIfExists(filePath: string): Promise<GeminiSettings | null> {
+  try {
+    const text = await readFile(filePath, "utf8");
+    const parsed = JSON.parse(text) as GeminiSettings;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed;
+    }
+    return null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}

--- a/packages/mcp/src/generators/index.ts
+++ b/packages/mcp/src/generators/index.ts
@@ -1,0 +1,18 @@
+export {
+  generateGeminiSettings,
+  writeGeminiSettings,
+  type GeminiSettings,
+} from "./gemini-settings.js";
+export {
+  generateClaudeSettings,
+  writeClaudeSettings,
+  type ClaudeSettings,
+  type ClaudeMcpJson,
+  type ClaudeLocalSettings,
+} from "./claude-settings.js";
+export {
+  deriveAllowedTools,
+  formatMcpToolName,
+  type DeriveAllowedToolsOptions,
+  type ToolsByServer,
+} from "./allowed-tools.js";

--- a/packages/mcp/src/http-client.test.ts
+++ b/packages/mcp/src/http-client.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  callHttpTool,
+  encodeQueryString,
+  joinUrl,
+  substitutePathParams,
+  type FetchLike,
+} from "./http-client.js";
+import type { HttpToolDefinition } from "./types.js";
+
+describe("substitutePathParams", () => {
+  it("replaces a single placeholder and removes the key from rest", () => {
+    const { path, rest, missing } = substitutePathParams("/api/duties/{id}", {
+      id: "42",
+      other: "keep",
+    });
+    expect(path).toBe("/api/duties/42");
+    expect(rest).toEqual({ other: "keep" });
+    expect(missing).toEqual([]);
+  });
+
+  it("URL-encodes substituted values", () => {
+    const { path } = substitutePathParams("/api/users/{name}", {
+      name: "al ice/bob",
+    });
+    expect(path).toBe("/api/users/al%20ice%2Fbob");
+  });
+
+  it("reports missing placeholders", () => {
+    const { path, missing } = substitutePathParams("/api/{a}/{b}", { a: "1" });
+    expect(path).toBe("/api/1/{b}");
+    expect(missing).toEqual(["b"]);
+  });
+
+  it("treats null or undefined values as missing", () => {
+    const { missing } = substitutePathParams("/api/{a}", { a: null });
+    expect(missing).toEqual(["a"]);
+  });
+
+  it("does not mutate the original args object", () => {
+    const args = { id: "1" };
+    substitutePathParams("/api/{id}", args);
+    expect(args).toEqual({ id: "1" });
+  });
+});
+
+describe("encodeQueryString", () => {
+  it("encodes scalar values", () => {
+    expect(encodeQueryString({ a: "1", b: 2, c: true })).toBe("a=1&b=2&c=true");
+  });
+
+  it("skips undefined and null values", () => {
+    expect(encodeQueryString({ a: "1", b: undefined, c: null })).toBe("a=1");
+  });
+
+  it("repeats array keys", () => {
+    expect(encodeQueryString({ tag: ["a", "b", "c"] })).toBe(
+      "tag=a&tag=b&tag=c",
+    );
+  });
+
+  it("JSON-stringifies nested objects", () => {
+    const qs = encodeQueryString({ filter: { a: 1 } });
+    expect(qs).toContain("filter=");
+    expect(decodeURIComponent(qs.split("=")[1]!)).toBe('{"a":1}');
+  });
+});
+
+describe("joinUrl", () => {
+  it("removes trailing slashes from base and ensures leading slash on path", () => {
+    expect(joinUrl("http://x.test/", "api/y")).toBe("http://x.test/api/y");
+    expect(joinUrl("http://x.test", "/api/y")).toBe("http://x.test/api/y");
+    expect(joinUrl("http://x.test//", "/api/y")).toBe("http://x.test/api/y");
+  });
+});
+
+function makeFetchMock(impl: (url: string, init?: Parameters<FetchLike>[1]) => {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  body: string;
+}): { fetch: FetchLike; calls: Array<{ url: string; init?: Parameters<FetchLike>[1] }> } {
+  const calls: Array<{ url: string; init?: Parameters<FetchLike>[1] }> = [];
+  const fetchImpl: FetchLike = vi.fn(async (url, init) => {
+    calls.push({ url, init });
+    const result = impl(url, init);
+    return {
+      ok: result.ok,
+      status: result.status,
+      statusText: result.statusText,
+      text: async () => result.body,
+    };
+  });
+  return { fetch: fetchImpl, calls };
+}
+
+const getTool: HttpToolDefinition = {
+  name: "list_duties",
+  method: "GET",
+  path: "/api/duties",
+};
+
+const postTool: HttpToolDefinition = {
+  name: "create_duty",
+  method: "POST",
+  path: "/api/duties",
+};
+
+const pathParamTool: HttpToolDefinition = {
+  name: "get_duty",
+  method: "GET",
+  path: "/api/duties/{id}",
+};
+
+describe("callHttpTool", () => {
+  it("performs a GET with query string from leftover args", async () => {
+    const mock = makeFetchMock(() => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      body: '{"items":[]}',
+    }));
+    const result = await callHttpTool({
+      tool: getTool,
+      args: { status: "open", limit: 5 },
+      baseUrl: "http://backend.test/",
+      fetch: mock.fetch,
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toBe('{"items":[]}');
+    expect(mock.calls).toHaveLength(1);
+    expect(mock.calls[0]!.url).toBe(
+      "http://backend.test/api/duties?status=open&limit=5",
+    );
+    expect(mock.calls[0]!.init?.method).toBe("GET");
+    expect(mock.calls[0]!.init?.body).toBeUndefined();
+  });
+
+  it("sends JSON body for POST and sets content-type", async () => {
+    const mock = makeFetchMock(() => ({
+      ok: true,
+      status: 201,
+      statusText: "Created",
+      body: '{"id":"new-1"}',
+    }));
+    await callHttpTool({
+      tool: postTool,
+      args: { title: "t", priority: 3 },
+      baseUrl: "http://backend.test",
+      fetch: mock.fetch,
+    });
+    const init = mock.calls[0]!.init!;
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(JSON.stringify({ title: "t", priority: 3 }));
+    expect(init.headers?.["content-type"]).toBe("application/json");
+  });
+
+  it("substitutes path params and excludes them from the query / body", async () => {
+    const mock = makeFetchMock(() => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      body: "{}",
+    }));
+    await callHttpTool({
+      tool: pathParamTool,
+      args: { id: "abc", include: "related" },
+      baseUrl: "http://backend.test",
+      fetch: mock.fetch,
+    });
+    expect(mock.calls[0]!.url).toBe(
+      "http://backend.test/api/duties/abc?include=related",
+    );
+  });
+
+  it("returns an isError ToolResult when a path param is missing", async () => {
+    const mock = makeFetchMock(() => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      body: "",
+    }));
+    const result = await callHttpTool({
+      tool: pathParamTool,
+      args: {},
+      baseUrl: "http://backend.test",
+      fetch: mock.fetch,
+    });
+    expect(result.isError).toBe(true);
+    expect(mock.calls).toHaveLength(0);
+  });
+
+  it("maps 4xx responses into isError tool results", async () => {
+    const mock = makeFetchMock(() => ({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      body: '{"error":"missing"}',
+    }));
+    const result = await callHttpTool({
+      tool: pathParamTool,
+      args: { id: "xxx" },
+      baseUrl: "http://backend.test",
+      fetch: mock.fetch,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/HTTP 404/);
+    expect(result.content[0]!.text).toMatch(/missing/);
+  });
+
+  it("maps network errors into isError tool results", async () => {
+    const fetchImpl: FetchLike = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    const result = await callHttpTool({
+      tool: getTool,
+      args: {},
+      baseUrl: "http://backend.test",
+      fetch: fetchImpl,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/ECONNREFUSED/);
+  });
+
+  it("merges per-server and per-tool headers (tool wins)", async () => {
+    const mock = makeFetchMock(() => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      body: "",
+    }));
+    const toolWithHeader: HttpToolDefinition = {
+      ...getTool,
+      headers: { "x-tool": "yes", authorization: "bearer TOOL" },
+    };
+    await callHttpTool({
+      tool: toolWithHeader,
+      args: {},
+      baseUrl: "http://backend.test",
+      headers: { "x-base": "yes", authorization: "bearer BASE" },
+      fetch: mock.fetch,
+    });
+    const headers = mock.calls[0]!.init!.headers!;
+    expect(headers["x-base"]).toBe("yes");
+    expect(headers["x-tool"]).toBe("yes");
+    expect(headers["authorization"]).toBe("bearer TOOL");
+  });
+});

--- a/packages/mcp/src/http-client.ts
+++ b/packages/mcp/src/http-client.ts
@@ -1,0 +1,187 @@
+import type { HttpToolDefinition, ToolArgs, ToolResult } from "./types.js";
+
+/** Minimal fetch signature the helper relies on. */
+export type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  statusText: string;
+  text(): Promise<string>;
+}>;
+
+/** Options for a single HTTP tool invocation. */
+export interface CallHttpToolOptions {
+  tool: HttpToolDefinition;
+  args: ToolArgs;
+  baseUrl: string;
+  headers?: Record<string, string>;
+  fetch?: FetchLike;
+  signal?: AbortSignal;
+}
+
+const PATH_PARAM_PATTERN = /\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
+const BODY_METHODS = new Set(["POST", "PUT", "PATCH"]);
+
+/**
+ * Substitute `{name}` segments in `path` using values consumed from `args`.
+ * Consumed keys are removed from the returned `rest` so they do not leak into
+ * the query string or body.
+ */
+export function substitutePathParams(
+  path: string,
+  args: ToolArgs,
+): { path: string; rest: ToolArgs; missing: string[] } {
+  const missing: string[] = [];
+  const rest: ToolArgs = { ...args };
+  const substituted = path.replace(PATH_PARAM_PATTERN, (_match, rawKey) => {
+    const key = rawKey as string;
+    if (!(key in rest)) {
+      missing.push(key);
+      return `{${key}}`;
+    }
+    const value = rest[key];
+    delete rest[key];
+    if (value === undefined || value === null) {
+      missing.push(key);
+      return `{${key}}`;
+    }
+    return encodeURIComponent(String(value));
+  });
+  return { path: substituted, rest, missing };
+}
+
+/**
+ * Build a URL-encoded query string from an arg bag. Arrays are repeated;
+ * nested objects are JSON-stringified. `undefined` / `null` values are
+ * skipped so optional params disappear silently.
+ */
+export function encodeQueryString(args: ToolArgs): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(args)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item === undefined || item === null) continue;
+        params.append(key, typeof item === "object" ? JSON.stringify(item) : String(item));
+      }
+      continue;
+    }
+    if (typeof value === "object") {
+      params.append(key, JSON.stringify(value));
+      continue;
+    }
+    params.append(key, String(value));
+  }
+  return params.toString();
+}
+
+/**
+ * Join a base URL and a (possibly substituted) path without double-slashes.
+ */
+export function joinUrl(baseUrl: string, path: string): string {
+  const trimmedBase = baseUrl.replace(/\/+$/, "");
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${trimmedBase}${trimmedPath}`;
+}
+
+/**
+ * Execute an HTTP tool call and convert the response into an MCP-shaped
+ * `ToolResult`. 4xx / 5xx responses are mapped to `isError: true` so the LLM
+ * sees the failure and can choose to retry or report.
+ */
+export async function callHttpTool(options: CallHttpToolOptions): Promise<ToolResult> {
+  const {
+    tool,
+    args,
+    baseUrl,
+    headers: serverHeaders = {},
+    fetch: fetchImpl = globalThis.fetch as unknown as FetchLike,
+    signal,
+  } = options;
+
+  if (!fetchImpl) {
+    throw new Error(
+      "callHttpTool: no fetch implementation available. Node 18+ ships `globalThis.fetch`; in older runtimes pass `fetch` explicitly.",
+    );
+  }
+
+  const { path: resolvedPath, rest, missing } = substitutePathParams(tool.path, args);
+  if (missing.length > 0) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: `Tool "${tool.name}" missing required path parameter(s): ${missing.join(", ")}`,
+        },
+      ],
+    };
+  }
+
+  let url = joinUrl(baseUrl, resolvedPath);
+  const method = tool.method.toUpperCase();
+  let body: string | undefined;
+
+  const mergedHeaders: Record<string, string> = {
+    accept: "application/json",
+    ...serverHeaders,
+    ...(tool.headers ?? {}),
+  };
+
+  if (BODY_METHODS.has(method)) {
+    if (Object.keys(rest).length > 0) {
+      body = JSON.stringify(rest);
+      mergedHeaders["content-type"] = mergedHeaders["content-type"] ?? "application/json";
+    }
+  } else if (Object.keys(rest).length > 0) {
+    const qs = encodeQueryString(rest);
+    if (qs.length > 0) url = url.includes("?") ? `${url}&${qs}` : `${url}?${qs}`;
+  }
+
+  let response: Awaited<ReturnType<FetchLike>>;
+  try {
+    const init: Parameters<FetchLike>[1] = {
+      method,
+      headers: mergedHeaders,
+    };
+    if (body !== undefined) init.body = body;
+    if (signal !== undefined) init.signal = signal;
+    response = await fetchImpl(url, init);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: `Tool "${tool.name}" request failed: ${message}`,
+        },
+      ],
+    };
+  }
+
+  const rawText = await response.text();
+
+  if (!response.ok) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: `Tool "${tool.name}" HTTP ${response.status} ${response.statusText}\n${rawText}`,
+        },
+      ],
+    };
+  }
+
+  return {
+    content: [{ type: "text", text: rawText }],
+  };
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,57 @@
+export type {
+  HttpMethod,
+  JsonSchema,
+  ToolArgs,
+  HttpToolDefinition,
+  ToolResult,
+  McpServerEntryConfig,
+  McpServersConfig,
+  CliTarget,
+} from "./types.js";
+
+export { defineHttpTool } from "./define-http-tool.js";
+
+export {
+  augmentSchemaForConfirmation,
+  checkConfirmation,
+  stripConfirmation,
+  type ConfirmationAugmentedSchema,
+} from "./confirmation.js";
+
+export {
+  callHttpTool,
+  substitutePathParams,
+  encodeQueryString,
+  joinUrl,
+  type CallHttpToolOptions,
+  type FetchLike,
+} from "./http-client.js";
+
+export {
+  createMcpServer,
+  type CreateMcpServerOptions,
+  type McpServerHandle,
+} from "./create-mcp-server.js";
+
+export {
+  prepareMcpWorkspace,
+  type PrepareMcpWorkspaceOptions,
+  type PreparedMcpWorkspace,
+} from "./prepare-workspace.js";
+
+// Re-export generators from the top-level entry for convenience. The
+// `./generators` subpath export is also available for tree-shaking fans.
+export {
+  generateGeminiSettings,
+  writeGeminiSettings,
+  generateClaudeSettings,
+  writeClaudeSettings,
+  deriveAllowedTools,
+  formatMcpToolName,
+  type GeminiSettings,
+  type ClaudeSettings,
+  type ClaudeMcpJson,
+  type ClaudeLocalSettings,
+  type DeriveAllowedToolsOptions,
+  type ToolsByServer,
+} from "./generators/index.js";

--- a/packages/mcp/src/prepare-workspace.test.ts
+++ b/packages/mcp/src/prepare-workspace.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { prepareMcpWorkspace } from "./prepare-workspace.js";
+
+describe("prepareMcpWorkspace", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "prepare-mcp-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes Gemini settings for cli=gemini", async () => {
+    const result = await prepareMcpWorkspace(dir, {
+      cli: "gemini",
+      mcpServers: { api: { command: "node" } },
+    });
+    expect(result.geminiSettingsPath).toBe(
+      join(dir, ".gemini", "settings.json"),
+    );
+    expect(result.mcpJsonPath).toBeUndefined();
+    const parsed = JSON.parse(
+      await readFile(result.geminiSettingsPath!, "utf8"),
+    );
+    expect(parsed.mcpServers.api).toEqual({ command: "node" });
+  });
+
+  it("writes Claude settings for cli=claude", async () => {
+    const result = await prepareMcpWorkspace(dir, {
+      cli: "claude",
+      mcpServers: { api: { command: "node" } },
+    });
+    expect(result.mcpJsonPath).toBe(join(dir, ".mcp.json"));
+    expect(result.claudeLocalSettingsPath).toBe(
+      join(dir, ".claude", "settings.local.json"),
+    );
+    expect(result.geminiSettingsPath).toBeUndefined();
+
+    const mcp = JSON.parse(await readFile(result.mcpJsonPath!, "utf8"));
+    expect(mcp.mcpServers.api).toEqual({ command: "node" });
+    const local = JSON.parse(
+      await readFile(result.claudeLocalSettingsPath!, "utf8"),
+    );
+    expect(local.enableAllProjectMcpServers).toBe(true);
+  });
+
+  it("is idempotent across repeated invocations", async () => {
+    await prepareMcpWorkspace(dir, {
+      cli: "claude",
+      mcpServers: { api: { command: "node" } },
+    });
+    const second = await prepareMcpWorkspace(dir, {
+      cli: "claude",
+      mcpServers: { api: { command: "node" } },
+    });
+    const local = JSON.parse(
+      await readFile(second.claudeLocalSettingsPath!, "utf8"),
+    );
+    const count = (local.enabledMcpjsonServers as string[]).filter(
+      (n) => n === "api",
+    ).length;
+    expect(count).toBe(1);
+  });
+});

--- a/packages/mcp/src/prepare-workspace.ts
+++ b/packages/mcp/src/prepare-workspace.ts
@@ -1,0 +1,49 @@
+import { writeClaudeSettings } from "./generators/claude-settings.js";
+import { writeGeminiSettings } from "./generators/gemini-settings.js";
+import type { CliTarget, McpServersConfig } from "./types.js";
+
+export interface PrepareMcpWorkspaceOptions {
+  /** CLI the worktree will be used with. */
+  cli: CliTarget;
+  /** MCP server spawn configs to register. */
+  mcpServers: McpServersConfig;
+}
+
+/** Paths written by {@link prepareMcpWorkspace}. */
+export interface PreparedMcpWorkspace {
+  /** `.gemini/settings.json` (only present when `cli === "gemini"`). */
+  geminiSettingsPath?: string;
+  /** `.mcp.json` (only present when `cli === "claude"`). */
+  mcpJsonPath?: string;
+  /** `.claude/settings.local.json` (only present when `cli === "claude"`). */
+  claudeLocalSettingsPath?: string;
+}
+
+/**
+ * Place CLI-specific MCP config files in `cwd` so the CLI picks the
+ * configured servers up on launch.
+ *
+ * For Claude Code: writes `.mcp.json` (server definitions) plus
+ * `.claude/settings.local.json` (auto-approval so Claude does not prompt).
+ *
+ * For Gemini CLI: writes `.gemini/settings.json`.
+ *
+ * Existing config files are merged — callers do not lose unrelated settings.
+ */
+export async function prepareMcpWorkspace(
+  cwd: string,
+  options: PrepareMcpWorkspaceOptions,
+): Promise<PreparedMcpWorkspace> {
+  if (options.cli === "gemini") {
+    const geminiSettingsPath = await writeGeminiSettings(cwd, options.mcpServers);
+    return { geminiSettingsPath };
+  }
+  const { mcpJsonPath, localSettingsPath } = await writeClaudeSettings(
+    cwd,
+    options.mcpServers,
+  );
+  return {
+    mcpJsonPath,
+    claudeLocalSettingsPath: localSettingsPath,
+  };
+}

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -1,0 +1,93 @@
+/**
+ * Types for the `@synapse-chat/mcp` helper package.
+ *
+ * The package centres on two shapes:
+ *
+ * - {@link HttpToolDefinition} — a declarative description of a single
+ *   Backend HTTP endpoint that should be exposed as an MCP tool.
+ * - {@link McpServerEntryConfig} — the `.mcp.json` / `.gemini/settings.json`
+ *   entry used to spawn an MCP server from a CLI agent.
+ */
+
+/** HTTP methods the helper understands. */
+export type HttpMethod = "GET" | "HEAD" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+/**
+ * A JSON Schema object. Accepted as-is by the MCP SDK so callers can author
+ * schemas with any generator (hand-written, Zod → JSON Schema, OpenAPI, …).
+ * We keep this loose on purpose to avoid coupling the helper to a specific
+ * validator.
+ */
+export type JsonSchema = Record<string, unknown>;
+
+/** Primitive bag of arguments passed from the LLM to a tool invocation. */
+export type ToolArgs = Record<string, unknown>;
+
+/**
+ * Declarative definition of a Backend HTTP endpoint exposed as an MCP tool.
+ *
+ * `path` may contain `{placeholder}` segments that are filled from the
+ * incoming `args` at call time. Remaining args become the request body
+ * (POST/PUT/PATCH) or query string (GET/HEAD/DELETE).
+ */
+export interface HttpToolDefinition {
+  /** MCP-visible tool name. Must be unique within one server. */
+  readonly name: string;
+
+  /** Optional human-readable description shown to the LLM. */
+  readonly description?: string;
+
+  /** HTTP method used when the tool is invoked. */
+  readonly method: HttpMethod;
+
+  /**
+   * Request path (appended to the server `baseUrl`). May contain
+   * `{name}` placeholders that are substituted from the tool args.
+   */
+  readonly path: string;
+
+  /**
+   * JSON Schema for the tool input. Optional — omit for zero-arg tools.
+   * When {@link confirmation} is `true`, the helper automatically adds a
+   * `confirmed: boolean` property and marks it required; callers do not need
+   * to describe it themselves.
+   */
+  readonly inputSchema?: JsonSchema;
+
+  /**
+   * If `true`, the tool is treated as a destructive / side-effectful action
+   * and the helper enforces an explicit `confirmed: true` argument before
+   * issuing the HTTP call. A missing or falsy `confirmed` short-circuits
+   * with an MCP error response so the LLM can re-invoke intentionally.
+   */
+  readonly confirmation?: boolean;
+
+  /** Additional HTTP headers applied to this tool only. */
+  readonly headers?: Record<string, string>;
+}
+
+/**
+ * Response returned by a tool invocation. Roughly mirrors the MCP
+ * `CallToolResult` shape but with only the fields the helper emits.
+ */
+export interface ToolResult {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}
+
+/**
+ * One entry in a Gemini / Claude settings file. Mirrors the shape accepted
+ * by both CLIs: `command` + optional `args` + optional `env`.
+ */
+export interface McpServerEntryConfig {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+}
+
+/** Map of server name → spawn config, as used in Gemini / Claude settings. */
+export type McpServersConfig = Record<string, McpServerEntryConfig>;
+
+/** CLI target for generators that need CLI-specific formatting. */
+export type CliTarget = "claude" | "gemini";

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "dist", "node_modules"],
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,15 @@ importers:
 
   packages/core: {}
 
+  packages/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
+      '@synapse-chat/core':
+        specifier: file:../core
+        version: link:../core
+
   packages/react:
     dependencies:
       '@synapse-chat/core':
@@ -826,6 +835,12 @@ packages:
   '@gerrit0/mini-shiki@1.27.2':
     resolution: {integrity: sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -876,6 +891,16 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1295,6 +1320,10 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1309,8 +1338,19 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -1371,6 +1411,10 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -1390,12 +1434,20 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -1465,8 +1517,28 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1512,6 +1584,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1541,11 +1617,18 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.340:
     resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -1600,6 +1683,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1666,9 +1752,31 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.3.2:
+    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1693,6 +1801,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1713,6 +1824,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -1731,6 +1846,14 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1812,12 +1935,20 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+    engines: {node: '>=16.9.0'}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -1859,8 +1990,19 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -1897,6 +2039,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
@@ -1911,6 +2056,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1942,6 +2090,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2134,6 +2288,14 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2230,9 +2392,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -2264,11 +2434,30 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2318,6 +2507,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2325,6 +2518,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2352,6 +2548,10 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2372,6 +2572,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
@@ -2380,11 +2584,23 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
@@ -2432,6 +2648,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2451,6 +2671,10 @@ packages:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
@@ -2483,6 +2707,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -2493,6 +2728,22 @@ packages:
 
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -2521,6 +2772,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -2612,6 +2867,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -2647,6 +2906,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typedoc@0.27.9:
     resolution: {integrity: sha512-/z585740YHURLl9DN2jCWe6OW7zKYm6VoQ93H0sxZ1cwHQEQrUn5BJrEnkWhfzUdyO+BLGjnKUZ9iz9hKloFDw==}
@@ -2695,6 +2958,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -2703,6 +2970,10 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -2850,6 +3121,9 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -2892,6 +3166,14 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -3462,6 +3744,10 @@ snapshots:
       '@shikijs/types': 1.29.2
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@hono/node-server@1.19.14(hono@4.12.14)':
+    dependencies:
+      hono: 4.12.14
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -3519,6 +3805,28 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.14)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.3.2(express@5.2.1)
+      hono: 4.12.14
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3931,6 +4239,11 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3939,12 +4252,23 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -3986,6 +4310,20 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -4011,12 +4349,19 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -4080,7 +4425,20 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 17.7.2
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4118,6 +4476,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
@@ -4142,9 +4502,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.340: {}
 
   emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -4263,6 +4627,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -4345,7 +4711,53 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.3.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -4367,6 +4779,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.0: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -4382,6 +4796,17 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@4.1.0:
     dependencies:
@@ -4407,6 +4832,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.3
       mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -4510,11 +4939,21 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  hono@4.12.14: {}
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
 
   html-url-attributes@3.0.1: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -4553,7 +4992,13 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  inherits@2.0.4: {}
+
   inline-style-parser@0.2.7: {}
+
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -4580,6 +5025,8 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@4.0.0: {}
+
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
@@ -4589,6 +5036,8 @@ snapshots:
   isexe@2.0.0: {}
 
   jiti@2.6.1: {}
+
+  jose@6.2.2: {}
 
   js-tokens@4.0.0: {}
 
@@ -4634,6 +5083,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4907,6 +5360,10 @@ snapshots:
 
   mdurl@2.0.0: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromark-core-commonmark@2.0.3:
@@ -5107,9 +5564,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   min-indent@1.0.1: {}
 
@@ -5133,9 +5596,23 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   node-releases@2.0.37: {}
 
   nwsapi@2.2.23: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -5194,9 +5671,13 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -5211,6 +5692,8 @@ snapshots:
   picomatch@4.0.4: {}
 
   pify@4.0.1: {}
+
+  pkce-challenge@5.0.1: {}
 
   postcss@8.5.10:
     dependencies:
@@ -5230,13 +5713,31 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-dom@19.2.5(react@19.2.5):
     dependencies:
@@ -5315,6 +5816,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -5354,6 +5857,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rrweb-cssom@0.7.1: {}
 
   rrweb-cssom@0.8.0: {}
@@ -5378,6 +5891,33 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -5385,6 +5925,34 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.3: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -5404,6 +5972,8 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -5481,6 +6051,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
@@ -5511,6 +6083,12 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typedoc@0.27.9(typescript@5.7.3):
     dependencies:
@@ -5573,6 +6151,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  unpipe@1.0.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -5582,6 +6162,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vary@1.1.2: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -5707,6 +6289,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrappy@1.0.2: {}
+
   ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
@@ -5732,5 +6316,11 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
+  zod@4.3.6: {}
 
   zwitch@2.0.4: {}

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,7 +5,8 @@
   "entryPoints": [
     "packages/core",
     "packages/server",
-    "packages/react"
+    "packages/react",
+    "packages/mcp"
   ],
   "out": "docs/api",
   "readme": "README.md",


### PR DESCRIPTION
## Summary

Issue #3 の実装。アプリの Backend HTTP API を MCP tool として CLI エージェント（Claude Code / Gemini CLI）に露出する helper を `@synapse-chat/mcp` として新規パッケージで提供する。Managemaid の `duty-mcp-server.mjs` を書き直せる表現力を備え、vibe-admiral が将来 stub-cli + HTTP 直叩きから MCP に移行するときも同じ helper を使える。

## Changes

- **New package `@synapse-chat/mcp`** (`packages/mcp/`)
  - `defineHttpTool({ name, method, path, inputSchema, confirmation? })` — 宣言的 tool 定義 + build-time validation
  - `createMcpServer({ name, version, tools, baseUrl })` — MCP stdio server を 1 関数で起動（低レベル `Server` handle も公開）
  - `callHttpTool()` — `{param}` path placeholder 置換、GET/HEAD/DELETE は query、POST/PUT/PATCH は JSON body、4xx/5xx → MCP `isError` へ変換
  - **Confirmation ガード**: `confirmation: true` で `confirmed: boolean` が自動的に input schema に注入され、`true` 未指定なら HTTP を叩かず error response
  - Settings ファイル generator: Claude (`.mcp.json` + `.claude/settings.local.json`)、Gemini (`.gemini/settings.json`)。既存設定と merge して非破壊的
  - `deriveAllowedTools()` — `mcp__<srv>__<tool>` (Claude) / `<srv>__<tool>` (Gemini) 形式で allow-list 自動生成
- **`@synapse-chat/core`**: `CLIAdapter` に optional `prepareWorkspace?(cwd): Promise<void>` hook を予約追加（既存 adapter / `ProcessManager` に影響なし）
- **Docs**: `docs/mcp-helper-guide.md` 新規。README の Packages / Documentation 表・Layout ツリーを更新
- **Changeset**: `@synapse-chat/mcp` minor + `@synapse-chat/core` minor

既存の `allowedTools`/`disallowedTools` とは完全に共存可能（後方互換 100%）。

Ref #3

## Test plan

- [x] `pnpm install` — 新規 `@modelcontextprotocol/sdk@^1.29.0` が解決
- [x] `pnpm -r build` — 全 5 パッケージ + example アプリが tsc -b で pass
- [x] `pnpm -r test` — vitest run 全 pass (core: 4, server: 94, react: 61, **mcp: 61 (new)**)
- [x] `pnpm -r typecheck` — 全 pass
- [x] `pnpm lint` — warnings なし

### MCP package テストカバレッジ

- `define-http-tool.test.ts` (8) — name/method/path validation
- `confirmation.test.ts` (12) — schema augmentation / short-circuit / strip
- `http-client.test.ts` (17) — path params / query / body / headers / 4xx-5xx / network error
- `create-mcp-server.test.ts` (7) — in-memory client/server round-trip、confirmation gate、duplicate detection
- `generators/gemini-settings.test.ts` (4) — pure + fs + merge preservation
- `generators/claude-settings.test.ts` (5) — `.mcp.json` + `.claude/settings.local.json` + merge
- `generators/allowed-tools.test.ts` (5) — cli 別フォーマット
- `prepare-workspace.test.ts` (3) — cli 分岐 + idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)