### PR TITLE
feat: adapter-driven dispatch in ProcessManager

### DIFF
--- a/packages/core/src/cli-adapter.ts
+++ b/packages/core/src/cli-adapter.ts
@@ -15,6 +15,15 @@ export interface SessionOptions {
   disallowedTools?: string[];
   cwd?: string;
   env?: Record<string, string>;
+  /**
+   * Auto-approve all tool/permission prompts. Translates to CLI-specific flags:
+   * - Claude: `--dangerously-skip-permissions`
+   * - Gemini: `--yolo`
+   *
+   * Intended for non-interactive automated dispatches (e.g. background workers).
+   * Leave unset for interactive chat sessions where a human should approve.
+   */
+  autoApprove?: boolean;
 }
 
 /**

--- a/packages/server/src/adapters/claude.test.ts
+++ b/packages/server/src/adapters/claude.test.ts
@@ -65,6 +65,18 @@ describe("buildClaudeArgs", () => {
     expect(args[idx + 1]).toBe("You are helpful.");
   });
 
+  it("appends --dangerously-skip-permissions when autoApprove is true", () => {
+    const args = buildClaudeArgs({ autoApprove: true });
+    expect(args).toContain("--dangerously-skip-permissions");
+  });
+
+  it("omits --dangerously-skip-permissions when autoApprove is false or unset", () => {
+    expect(buildClaudeArgs({})).not.toContain("--dangerously-skip-permissions");
+    expect(buildClaudeArgs({ autoApprove: false })).not.toContain(
+      "--dangerously-skip-permissions",
+    );
+  });
+
   it("combines every option in a single invocation", () => {
     const args = buildClaudeArgs({
       prompt: "run",

--- a/packages/server/src/adapters/claude.ts
+++ b/packages/server/src/adapters/claude.ts
@@ -43,6 +43,9 @@ export function buildClaudeArgs(options: SessionOptions): string[] {
   if (options.systemPrompt) {
     args.push("--append-system-prompt", options.systemPrompt);
   }
+  if (options.autoApprove) {
+    args.push("--dangerously-skip-permissions");
+  }
 
   return args;
 }

--- a/packages/server/src/adapters/gemini.test.ts
+++ b/packages/server/src/adapters/gemini.test.ts
@@ -25,6 +25,22 @@ describe("buildGeminiArgs", () => {
     });
     expect(args).toEqual(["--prompt", "hi"]);
   });
+
+  it("appends --yolo when autoApprove is true", () => {
+    expect(buildGeminiArgs({ autoApprove: true })).toEqual(["--yolo"]);
+    expect(buildGeminiArgs({ prompt: "hi", autoApprove: true })).toEqual([
+      "--prompt",
+      "hi",
+      "--yolo",
+    ]);
+  });
+
+  it("omits --yolo when autoApprove is false or unset", () => {
+    expect(buildGeminiArgs({ prompt: "hi" })).not.toContain("--yolo");
+    expect(buildGeminiArgs({ prompt: "hi", autoApprove: false })).not.toContain(
+      "--yolo",
+    );
+  });
 });
 
 describe("parseGeminiOutput", () => {

--- a/packages/server/src/adapters/gemini.ts
+++ b/packages/server/src/adapters/gemini.ts
@@ -21,6 +21,9 @@ export function buildGeminiArgs(options: SessionOptions): string[] {
   if (options.prompt) {
     args.push("--prompt", options.prompt);
   }
+  if (options.autoApprove) {
+    args.push("--yolo");
+  }
   return args;
 }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,11 +3,13 @@ export {
   COMMANDER_ALLOWED_TOOLS,
   isRetryableError,
   isRateLimitError,
+  type DispatchOptions,
 } from "./process-manager.js";
 export {
   attachStdoutProcessor,
   attachStderrProcessor,
   type StreamCallbacks,
+  type StreamLineParser,
 } from "./stream-processor.js";
 export {
   parseStreamMessage,

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -3,10 +3,13 @@ import { EventEmitter } from "node:events";
 import { mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type {
+  CLIAdapter,
   ImageAttachment,
   ProcessManagerLike,
   SendResult,
+  SessionOptions,
 } from "@synapse-chat/core";
+import { claudeAdapter } from "./adapters/claude.js";
 import {
   isRetryableError,
   isRateLimitError,
@@ -20,6 +23,17 @@ export const COMMANDER_ALLOWED_TOOLS =
   "Bash,Read,Glob,Grep,WebSearch,WebFetch";
 
 const CLI_PATH = process.env.CLAUDE_CLI_PATH ?? "claude";
+
+export interface DispatchOptions
+  extends Omit<SessionOptions, "cwd" | "env"> {
+  cwd: string;
+  /** CLI adapter to spawn. Defaults to {@link claudeAdapter}. */
+  adapter?: CLIAdapter;
+  /** Extra env vars merged into the spawned process. */
+  extraEnv?: Record<string, string>;
+  /** Optional log file path; per-line stream messages are appended as JSON. */
+  logFilePath?: string;
+}
 
 export class ProcessManager extends EventEmitter implements ProcessManagerLike {
   private processes = new Map<string, ChildProcess>();
@@ -236,6 +250,44 @@ export class ProcessManager extends EventEmitter implements ProcessManagerLike {
     return proc;
   }
 
+  /**
+   * Adapter-driven dispatch: spawn an arbitrary CLI (Claude, Gemini, custom)
+   * with an adapter that knows how to translate {@link SessionOptions} into
+   * argv and how to parse stdout into {@link StreamMessage}s.
+   *
+   * Unlike {@link dispatchSortie}, this method is not Claude-specific. Use it
+   * for one-off automated work that should be fired against the configured
+   * adapter (e.g. background conflict resolution).
+   */
+  dispatch(id: string, options: DispatchOptions): ChildProcess {
+    const adapter = options.adapter ?? claudeAdapter;
+    const sessionOptions: SessionOptions = {};
+    if (options.prompt !== undefined) sessionOptions.prompt = options.prompt;
+    if (options.systemPrompt !== undefined)
+      sessionOptions.systemPrompt = options.systemPrompt;
+    if (options.resumeSessionId !== undefined)
+      sessionOptions.resumeSessionId = options.resumeSessionId;
+    if (options.allowedTools !== undefined)
+      sessionOptions.allowedTools = options.allowedTools;
+    if (options.disallowedTools !== undefined)
+      sessionOptions.disallowedTools = options.disallowedTools;
+    if (options.autoApprove !== undefined)
+      sessionOptions.autoApprove = options.autoApprove;
+    const args = adapter.buildArgs(sessionOptions);
+
+    const proc = spawn(adapter.command, args, {
+      cwd: options.cwd,
+      env: {
+        ...process.env,
+        ...options.extraEnv,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    this.setupProcess(id, proc, options.logFilePath, adapter);
+    return proc;
+  }
+
   resumeSession(
     id: string,
     sessionId: string,
@@ -308,6 +360,7 @@ export class ProcessManager extends EventEmitter implements ProcessManagerLike {
     id: string,
     proc: ChildProcess,
     logFilePath?: string,
+    adapter?: CLIAdapter,
   ): void {
     this.processes.set(id, proc);
     this.emit("spawn", id);
@@ -335,7 +388,11 @@ export class ProcessManager extends EventEmitter implements ProcessManagerLike {
       },
     };
 
-    attachStdoutProcessor(proc, shortId, logFilePath, callbacks);
+    const parseLine = adapter
+      ? (line: string) =>
+          adapter.parseOutput(line) as Record<string, unknown> | null
+      : undefined;
+    attachStdoutProcessor(proc, shortId, logFilePath, callbacks, parseLine);
     attachStderrProcessor(proc, shortId, callbacks);
 
     proc.on("exit", (code) => {

--- a/packages/server/src/stream-processor.ts
+++ b/packages/server/src/stream-processor.ts
@@ -29,12 +29,23 @@ export interface StreamCallbacks {
   onError: (error: Error) => void;
 }
 
+export type StreamLineParser = (
+  line: string,
+) => Record<string, unknown> | null;
+
 export function attachStdoutProcessor(
   proc: ChildProcess,
   shortId: string,
   logFilePath: string | undefined,
   callbacks: StreamCallbacks,
+  parseLine?: StreamLineParser,
 ): void {
+  const parser: StreamLineParser =
+    parseLine ??
+    ((line) =>
+      safeJsonParse<Record<string, unknown>>(line, {
+        source: `proc:${shortId}.stdout`,
+      }));
   let buffer = "";
   proc.stdout?.on("data", (chunk: Buffer) => {
     buffer += chunk.toString();
@@ -43,9 +54,7 @@ export function attachStdoutProcessor(
 
     for (const line of lines) {
       if (!line.trim()) continue;
-      const msg = safeJsonParse<Record<string, unknown>>(line, {
-        source: `proc:${shortId}.stdout`,
-      });
+      const msg = parser(line);
       if (!msg) continue;
       callbacks.onMessage(msg);
 


### PR DESCRIPTION
## Summary

- `ProcessManager.dispatch(id, options)` を新設。`adapter` で `claudeAdapter` / `geminiAdapter` / 任意 `CLIAdapter` を選択可能（default = `claudeAdapter`）
- `SessionOptions.autoApprove` 追加 → Claude `--dangerously-skip-permissions` / Gemini `--yolo` に翻訳
- `attachStdoutProcessor` に optional `parseLine` を追加し、adapter ごとの parser に差し替え可能に
- 既存メソッド (`sortie` / `dispatchSortie` / `launchCommander` / `resumeCommander` / `resumeSession`) の挙動は変えず Claude 直 spawn のまま

## Test plan

- [x] `pnpm build` 全 package 成功
- [x] `pnpm typecheck` 全 package 成功
- [x] `pnpm lint` 成功
- [x] `pnpm --filter @synapse-chat/server test` 98 / 98 pass (新規 4 件 + 既存 94 件)
- [ ] downstream consumer (launchport の AI conflict resolver) 切替後の手動動作確認

## Notes

- `ProcessManagerLike` interface には `dispatch` を追加していない (IPC 経由は別 PR で対応する想定)
- `pnpm --filter @synapse-chat/react test` の `indexedDB.test.ts` が `fake-indexeddb` 解決失敗で fail するが、これは main 上でも同様に fail する pre-existing issue
- 後段の launchport 修正: mizunowanko/launchport#50

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)