### PR TITLE
feat: StreamMessage に token usage tracking を追加する

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export type {
   ImageAttachment,
   StreamMessage,
   StreamMessageType,
+  TokenUsage,
 } from "./types.js";
 export type { CLIAdapter, SessionOptions } from "./cli-adapter.js";
 export type {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -24,6 +24,20 @@ export interface ImageAttachment {
 }
 
 /**
+ * Normalized token usage attached to a `result` {@link StreamMessage}.
+ *
+ * Adapters populate this from the underlying CLI's session-end metadata.
+ * `cacheRead` and `cacheWrite` map to prompt-cache hit / write counts when
+ * the CLI exposes them.
+ */
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+}
+
+/**
  * A single normalized event from a CLI stream.
  *
  * Adapters are responsible for mapping CLI-specific stdout lines to this shape
@@ -44,5 +58,7 @@ export interface StreamMessage {
   timestamp?: number;
   images?: ImageAttachment[];
   imageCount?: number;
+  /** Token usage; populated by adapters on `type: "result"` messages when available. */
+  usage?: TokenUsage;
   [key: string]: unknown;
 }

--- a/packages/react/src/hooks/useTokenUsage.test.tsx
+++ b/packages/react/src/hooks/useTokenUsage.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { StreamMessage } from "@synapse-chat/core";
+import { useTokenUsage } from "./useTokenUsage.js";
+
+describe("useTokenUsage", () => {
+  it("returns all-zero totals for an empty list", () => {
+    const { result } = renderHook(() => useTokenUsage([]));
+    expect(result.current).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      resultCount: 0,
+    });
+  });
+
+  it("sums usage across multiple result messages", () => {
+    const messages: StreamMessage[] = [
+      {
+        type: "result",
+        content: "first",
+        usage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheRead: 10,
+          cacheWrite: 5,
+        },
+      },
+      {
+        type: "result",
+        content: "second",
+        usage: { inputTokens: 200, outputTokens: 80 },
+      },
+    ];
+    const { result } = renderHook(() => useTokenUsage(messages));
+    expect(result.current).toEqual({
+      inputTokens: 300,
+      outputTokens: 130,
+      cacheRead: 10,
+      cacheWrite: 5,
+      resultCount: 2,
+    });
+  });
+
+  it("ignores result messages without usage", () => {
+    const messages: StreamMessage[] = [
+      { type: "result", content: "no usage" },
+      {
+        type: "result",
+        content: "with usage",
+        usage: { inputTokens: 7, outputTokens: 3 },
+      },
+    ];
+    const { result } = renderHook(() => useTokenUsage(messages));
+    expect(result.current).toEqual({
+      inputTokens: 7,
+      outputTokens: 3,
+      cacheRead: 0,
+      cacheWrite: 0,
+      resultCount: 1,
+    });
+  });
+
+  it("ignores non-result messages even when they carry a usage field", () => {
+    const messages: StreamMessage[] = [
+      { type: "assistant", content: "hi" },
+      {
+        type: "user",
+        content: "smuggled",
+        usage: { inputTokens: 999, outputTokens: 999 },
+      },
+    ];
+    const { result } = renderHook(() => useTokenUsage(messages));
+    expect(result.current.resultCount).toBe(0);
+    expect(result.current.inputTokens).toBe(0);
+  });
+
+  it("re-derives when the messages array reference changes", () => {
+    const initial: StreamMessage[] = [
+      {
+        type: "result",
+        content: "a",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      },
+    ];
+    const { result, rerender } = renderHook(
+      ({ msgs }: { msgs: StreamMessage[] }) => useTokenUsage(msgs),
+      { initialProps: { msgs: initial } },
+    );
+    expect(result.current.inputTokens).toBe(1);
+
+    const next: StreamMessage[] = [
+      ...initial,
+      {
+        type: "result",
+        content: "b",
+        usage: { inputTokens: 4, outputTokens: 2 },
+      },
+    ];
+    rerender({ msgs: next });
+    expect(result.current).toEqual({
+      inputTokens: 5,
+      outputTokens: 3,
+      cacheRead: 0,
+      cacheWrite: 0,
+      resultCount: 2,
+    });
+  });
+});

--- a/packages/react/src/hooks/useTokenUsage.ts
+++ b/packages/react/src/hooks/useTokenUsage.ts
@@ -1,0 +1,53 @@
+import { useMemo } from "react";
+import type { StreamMessage } from "@synapse-chat/core";
+
+/**
+ * Cumulative token usage derived from a list of {@link StreamMessage}s.
+ *
+ * Cache fields default to zero (rather than being omitted) so consumers can
+ * read them without null-checks. `resultCount` is the number of `result`
+ * messages whose `usage` was summed — useful for averaging or detecting that
+ * no usage data has arrived yet.
+ */
+export interface CumulativeTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheRead: number;
+  cacheWrite: number;
+  resultCount: number;
+}
+
+/**
+ * Sum {@link StreamMessage.usage} across `result` messages to produce the
+ * session's cumulative token count.
+ *
+ * Pass the `messages` array returned by {@link useChat} (or any per-session
+ * StreamMessage list). The hook is a pure derivation memoized on the array
+ * reference, so it re-computes only when `useChat` produces a new array.
+ *
+ * Messages without `usage` and non-`result` messages are ignored.
+ */
+export function useTokenUsage(
+  messages: readonly StreamMessage[],
+): CumulativeTokenUsage {
+  return useMemo(() => {
+    const totals: CumulativeTokenUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      resultCount: 0,
+    };
+    for (const msg of messages) {
+      if (msg.type !== "result") continue;
+      const usage = msg.usage;
+      if (!usage) continue;
+      totals.inputTokens += usage.inputTokens;
+      totals.outputTokens += usage.outputTokens;
+      totals.cacheRead += usage.cacheRead ?? 0;
+      totals.cacheWrite += usage.cacheWrite ?? 0;
+      totals.resultCount += 1;
+    }
+    return totals;
+  }, [messages]);
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -14,6 +14,10 @@ export {
   useWebSocket,
   type UseWebSocketResult,
 } from "./hooks/useWebSocket.js";
+export {
+  useTokenUsage,
+  type CumulativeTokenUsage,
+} from "./hooks/useTokenUsage.js";
 
 export {
   WSClient,
@@ -41,4 +45,5 @@ export type {
   StreamMessage,
   StreamMessageType,
   ImageAttachment,
+  TokenUsage,
 } from "@synapse-chat/core";

--- a/packages/server/src/adapters/gemini.test.ts
+++ b/packages/server/src/adapters/gemini.test.ts
@@ -140,6 +140,67 @@ describe("parseGeminiOutput", () => {
       content: line,
     });
   });
+
+  it("emits a result message with normalized usage (Gemini-style camelCase)", () => {
+    const line = JSON.stringify({
+      type: "result",
+      result: "ok",
+      usageMetadata: {
+        promptTokenCount: 1200,
+        candidatesTokenCount: 300,
+        cachedContentTokenCount: 80,
+      },
+    });
+    expect(parseGeminiOutput(line)).toEqual({
+      type: "result",
+      content: "ok",
+      usage: {
+        inputTokens: 1200,
+        outputTokens: 300,
+        cacheRead: 80,
+      },
+    });
+  });
+
+  it("emits a result message with normalized usage (Claude-style snake_case)", () => {
+    const line = JSON.stringify({
+      type: "result",
+      result: "done",
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_input_tokens: 2,
+        cache_creation_input_tokens: 1,
+      },
+    });
+    expect(parseGeminiOutput(line)).toEqual({
+      type: "result",
+      content: "done",
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        cacheRead: 2,
+        cacheWrite: 1,
+      },
+    });
+  });
+
+  it("emits a result with no usage when usage block is missing", () => {
+    const line = JSON.stringify({ type: "result", result: "no usage" });
+    expect(parseGeminiOutput(line)).toEqual({
+      type: "result",
+      content: "no usage",
+    });
+  });
+
+  it("ignores result-typed payload with empty result string", () => {
+    const line = JSON.stringify({ type: "result", result: "" });
+    // Falls through to text/content fallback → raw line as assistant
+    expect(parseGeminiOutput(line)).toEqual({
+      type: "assistant",
+      content: line,
+    });
+  });
 });
 
 describe("formatGeminiInput", () => {

--- a/packages/server/src/adapters/gemini.ts
+++ b/packages/server/src/adapters/gemini.ts
@@ -1,4 +1,4 @@
-import type { CLIAdapter, SessionOptions, StreamMessage } from "@synapse-chat/core";
+import type { CLIAdapter, SessionOptions, StreamMessage, TokenUsage } from "@synapse-chat/core";
 
 const GEMINI_RATE_LIMIT_PATTERNS: RegExp[] = [
   /\b429\b/,
@@ -73,12 +73,78 @@ function mapGeminiJsonToStreamMessage(
     return message;
   }
 
+  if (raw.type === "result") {
+    const result = (raw.result ?? raw.content ?? raw.text) as string | undefined;
+    if (typeof result !== "string" || result.length === 0) return null;
+    const message: StreamMessage = { type: "result", content: result };
+    const usage = extractGeminiUsage(raw);
+    if (usage) message.usage = usage;
+    return message;
+  }
+
   const text = raw.text ?? raw.content;
   if (typeof text === "string" && text.length > 0) {
     return { type: "assistant", content: text };
   }
 
   return null;
+}
+
+/**
+ * Extract token usage from a Gemini `result`-shaped JSON payload.
+ *
+ * Accepts either Claude-style snake_case (`input_tokens` / `output_tokens` /
+ * `cache_*_input_tokens`) or Gemini-style camelCase (`promptTokenCount`,
+ * `candidatesTokenCount`, `cachedContentTokenCount`). Returns null when no
+ * recognizable token fields are present.
+ */
+function extractGeminiUsage(
+  raw: Record<string, unknown>,
+): TokenUsage | null {
+  const usage = (raw.usage ?? raw.usageMetadata) as
+    | Record<string, unknown>
+    | undefined;
+  if (!usage || typeof usage !== "object") return null;
+
+  const inputTokens =
+    pickNumber(usage, "input_tokens") ??
+    pickNumber(usage, "inputTokens") ??
+    pickNumber(usage, "promptTokenCount") ??
+    0;
+  const outputTokens =
+    pickNumber(usage, "output_tokens") ??
+    pickNumber(usage, "outputTokens") ??
+    pickNumber(usage, "candidatesTokenCount") ??
+    0;
+  const cacheRead =
+    pickNumber(usage, "cache_read_input_tokens") ??
+    pickNumber(usage, "cacheReadInputTokens") ??
+    pickNumber(usage, "cachedContentTokenCount");
+  const cacheWrite =
+    pickNumber(usage, "cache_creation_input_tokens") ??
+    pickNumber(usage, "cacheCreationInputTokens");
+
+  if (
+    inputTokens === 0 &&
+    outputTokens === 0 &&
+    cacheRead === undefined &&
+    cacheWrite === undefined
+  ) {
+    return null;
+  }
+
+  const result: TokenUsage = { inputTokens, outputTokens };
+  if (cacheRead !== undefined && cacheRead > 0) result.cacheRead = cacheRead;
+  if (cacheWrite !== undefined && cacheWrite > 0) result.cacheWrite = cacheWrite;
+  return result;
+}
+
+function pickNumber(
+  source: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = source[key];
+  return typeof value === "number" ? value : undefined;
 }
 
 export function formatGeminiInput(message: string): string {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -15,6 +15,7 @@ export {
   parseStreamMessage,
   extractSessionId,
   extractResultUsage,
+  toTokenUsage,
   type ResultUsage,
 } from "./stream-parser.js";
 export { safeJsonParse, type ParseJsonSafeOptions } from "./util/json-safe.js";
@@ -40,6 +41,7 @@ export type {
   StreamMessage,
   StreamMessageType,
   ImageAttachment,
+  TokenUsage,
 } from "@synapse-chat/core";
 
 // CLI adapters (Claude, Gemini). Re-exported via the "./adapters" subpath too.

--- a/packages/server/src/stream-parser.test.ts
+++ b/packages/server/src/stream-parser.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { parseStreamMessage } from "./stream-parser.js";
+import {
+  extractResultUsage,
+  parseStreamMessage,
+  toTokenUsage,
+} from "./stream-parser.js";
 
 describe("parseStreamMessage", () => {
   // === tool_result ===
@@ -514,6 +518,61 @@ describe("parseStreamMessage", () => {
       });
       expect(result).toBeNull();
     });
+
+    it("attaches normalized usage from Claude-style result", () => {
+      const result = parseStreamMessage({
+        type: "result",
+        result: "all done",
+        total_cost_usd: 0.0123,
+        usage: {
+          input_tokens: 1000,
+          output_tokens: 250,
+          cache_read_input_tokens: 100,
+          cache_creation_input_tokens: 50,
+        },
+      });
+      expect(result).toEqual({
+        type: "result",
+        content: "all done",
+        usage: {
+          inputTokens: 1000,
+          outputTokens: 250,
+          cacheRead: 100,
+          cacheWrite: 50,
+        },
+        timestamp: expect.any(Number),
+      });
+    });
+
+    it("omits cache fields when adapter reports zero", () => {
+      const result = parseStreamMessage({
+        type: "result",
+        result: "all done",
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+        },
+      });
+      expect(result).toEqual({
+        type: "result",
+        content: "all done",
+        usage: { inputTokens: 10, outputTokens: 5 },
+        timestamp: expect.any(Number),
+      });
+    });
+
+    it("does not attach usage when result has neither cost nor usage block", () => {
+      const result = parseStreamMessage({
+        type: "result",
+        result: "all done",
+      });
+      expect(result).toEqual({
+        type: "result",
+        content: "all done",
+        timestamp: expect.any(Number),
+      });
+      expect(result).not.toHaveProperty("usage");
+    });
   });
 
   // === default (unknown types) ===
@@ -554,5 +613,78 @@ describe("parseStreamMessage", () => {
       const result = parseStreamMessage({ type: "unknown_type" });
       expect(result).toBeNull();
     });
+  });
+});
+
+describe("extractResultUsage", () => {
+  it("returns null for non-result types", () => {
+    expect(extractResultUsage({ type: "assistant" })).toBeNull();
+  });
+
+  it("returns null when result has neither cost nor usage", () => {
+    expect(extractResultUsage({ type: "result", result: "x" })).toBeNull();
+  });
+
+  it("preserves the legacy ResultUsage shape", () => {
+    const usage = extractResultUsage({
+      type: "result",
+      total_cost_usd: 0.5,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 2,
+        cache_read_input_tokens: 3,
+        cache_creation_input_tokens: 4,
+      },
+    });
+    expect(usage).toEqual({
+      inputTokens: 1,
+      outputTokens: 2,
+      cacheReadInputTokens: 3,
+      cacheCreationInputTokens: 4,
+      costUsd: 0.5,
+    });
+  });
+
+  it("defaults missing fields to zero when only cost is present", () => {
+    expect(
+      extractResultUsage({ type: "result", total_cost_usd: 0.01 }),
+    ).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      costUsd: 0.01,
+    });
+  });
+});
+
+describe("toTokenUsage", () => {
+  it("strips cost and renames cache fields", () => {
+    expect(
+      toTokenUsage({
+        inputTokens: 10,
+        outputTokens: 5,
+        cacheReadInputTokens: 7,
+        cacheCreationInputTokens: 3,
+        costUsd: 0.42,
+      }),
+    ).toEqual({
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheRead: 7,
+      cacheWrite: 3,
+    });
+  });
+
+  it("omits cache fields when zero", () => {
+    expect(
+      toTokenUsage({
+        inputTokens: 10,
+        outputTokens: 5,
+        cacheReadInputTokens: 0,
+        cacheCreationInputTokens: 0,
+        costUsd: 0,
+      }),
+    ).toEqual({ inputTokens: 10, outputTokens: 5 });
   });
 });

--- a/packages/server/src/stream-parser.ts
+++ b/packages/server/src/stream-parser.ts
@@ -1,4 +1,4 @@
-import type { StreamMessage } from "@synapse-chat/core";
+import type { StreamMessage, TokenUsage } from "@synapse-chat/core";
 
 /**
  * Token usage and cost extracted from a Claude CLI session `result` message.
@@ -71,6 +71,25 @@ export function extractResultUsage(
 }
 
 /**
+ * Project a {@link ResultUsage} onto the normalized {@link TokenUsage} shape
+ * carried by {@link StreamMessage}. Cache fields are omitted when zero so the
+ * payload stays minimal for adapters that don't report them.
+ */
+export function toTokenUsage(usage: ResultUsage): TokenUsage {
+  const result: TokenUsage = {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+  };
+  if (usage.cacheReadInputTokens > 0) {
+    result.cacheRead = usage.cacheReadInputTokens;
+  }
+  if (usage.cacheCreationInputTokens > 0) {
+    result.cacheWrite = usage.cacheCreationInputTokens;
+  }
+  return result;
+}
+
+/**
  * Transform raw Claude CLI stream-json output into a StreamMessage
  * that downstream consumers can display.
  *
@@ -129,10 +148,15 @@ function parseStreamMessageInner(
     case "result": {
       const result = raw.result as string | undefined;
       if (!result) return null;
-      return {
+      const message: StreamMessage = {
         type: "result",
         content: result,
       };
+      const usage = extractResultUsage(raw);
+      if (usage) {
+        message.usage = toTokenUsage(usage);
+      }
+      return message;
     }
 
     case "system": {


### PR DESCRIPTION
## Summary

`StreamMessage` に optional な `usage` フィールドを追加し、Claude / Gemini どちらの adapter も result メッセージに正規化された token usage を載せられるようにした。React 側は `useTokenUsage()` hook で session の累積 token を導出できる。

## Changes

- `@synapse-chat/core`
  - `TokenUsage` 型を新設（`inputTokens` / `outputTokens` / `cacheRead?` / `cacheWrite?`）
  - `StreamMessage` に `usage?: TokenUsage` フィールドを追加（index signature 経由なので破壊変更なし）

- `@synapse-chat/server`
  - `parseStreamMessage` の `case "result"` で `extractResultUsage()` を呼んで `TokenUsage` 形に正規化、`StreamMessage.usage` へ付与
  - `toTokenUsage(ResultUsage)` 投影ヘルパを追加（cost を落として cache フィールドをリネーム）
  - 既存 `extractResultUsage` / `ResultUsage` は無変更（後方互換維持）
  - Gemini adapter に result + usage 検出パスを追加（Claude 形式 snake_case と Gemini 形式 camelCase 両対応）

- `@synapse-chat/react`
  - `useTokenUsage(messages)` hook を追加。`useMemo` で result メッセージの usage を累積。session ID ベースではなく messages を引数に取る理由: `useChat` が既にセッション単位で messages を分離管理しており、グローバル store 新設より呼び出し側スコープで済ませる方が React 的に自然なため
  - `TokenUsage` / `useTokenUsage` / `CumulativeTokenUsage` を index から re-export

Closes #5

## Test plan

- `pnpm --filter @synapse-chat/core build` ✅
- `pnpm --filter @synapse-chat/server test` ✅ 111/111
- `pnpm --filter @synapse-chat/react test` ✅ 66/66 （新規 5 ケース含む）
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm build` ✅（example app も含めて pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)