### PR TITLE
feat: Supervisor の graceful shutdown と process health check を実装する

### DIFF
--- a/.changeset/supervisor-graceful-shutdown.md
+++ b/.changeset/supervisor-graceful-shutdown.md
@@ -1,0 +1,10 @@
+---
+"@synapse-chat/server": minor
+---
+
+`startSupervisor` adds graceful shutdown, PM worker health checks, and a restart cap.
+
+- `SupervisorOptions` gains `shutdownTimeout`, `healthCheckInterval`, `healthCheckTimeout`, `maxRestarts`, `onFatal`, `onTerminate`, and `installGlobalHandlers`. All optional; defaults preserve the previous behaviour (5s shutdown timeout, no health check, unbounded restarts).
+- `SupervisorHandle` exposes `stop()` as an alias for `shutdown()`. The `shutdown` sequence now SIGKILLs any child that fails to exit within `shutdownTimeout`, instead of leaving it dangling when the supervisor itself exits.
+- When `healthCheckInterval` is set, the supervisor pings the PM worker over IPC. Missed pongs (after `healthCheckTimeout`) cause a SIGKILL → restart cycle, catching hung CLI subprocesses.
+- When a child exceeds `maxRestarts`, `onFatal(label, count)` runs and the supervisor initiates its own shutdown so the embedding process can exit cleanly.

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -79,12 +79,32 @@ const handle = startSupervisor({
   wsServerChildScript: "/abs/path/to/ws-server.js",
   childEnv: { MY_APP_VAR: "value" },
   onCrash: (err, ctx) => console.error("supervisor crash", ctx, err),
+
+  // Graceful shutdown — IPC `supervisor:shutdown` first, then SIGKILL after this
+  // window if the children haven't exited.
+  shutdownTimeout: 5_000,
+
+  // Optional liveness probe for the PM worker. Sends an IPC ping every interval;
+  // if no pong is received within `healthCheckTimeout` the worker is SIGKILLed
+  // and restarted via the normal exit path. Omit to disable.
+  healthCheckInterval: 30_000,
+  healthCheckTimeout: 5_000,
+
+  // Cap restart attempts per child. Counter resets after the child stays alive
+  // for ~60s. When exceeded, `onFatal` is called and the supervisor shuts down.
+  maxRestarts: 5,
+  onFatal: (label, count) => {
+    console.error(`supervisor: ${label} died ${count}× — giving up`);
+  },
 });
 
-process.on("SIGTERM", () => handle.shutdown());
+// `stop()` is an alias for `shutdown()` — use whichever reads better.
+process.on("SIGTERM", () => handle.stop());
 ```
 
 The PM worker script should `import { ProcessManager } from "@synapse-chat/server"` and translate IPC commands via `IpcProcessManager`. See `vibe-admiral/engine/src/supervisor.ts` for a reference implementation.
+
+> **Health check scope**: pings target the PM worker only — the WS server child is consumer-supplied and not required to implement `ping`/`pong`. CLI subprocess hangs surface as PM worker latency, which is what the probe catches.
 
 ## Dependencies
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,7 +28,8 @@
   "files": [
     "dist",
     "src",
-    "!src/**/*.test.ts"
+    "!src/**/*.test.ts",
+    "!src/**/test-fixtures/**"
   ],
   "sideEffects": false,
   "scripts": {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -25,6 +25,7 @@ export {
   startSupervisor,
   type SupervisorOptions,
   type SupervisorHandle,
+  type ChildLabel,
 } from "./supervisor/supervisor.js";
 export {
   IpcProcessManager,

--- a/packages/server/src/supervisor/index.ts
+++ b/packages/server/src/supervisor/index.ts
@@ -2,6 +2,7 @@ export {
   startSupervisor,
   type SupervisorOptions,
   type SupervisorHandle,
+  type ChildLabel,
 } from "./supervisor.js";
 export { IpcProcessManager, type IpcChannel } from "./ipc-process-manager.js";
 export type {

--- a/packages/server/src/supervisor/supervisor.test.ts
+++ b/packages/server/src/supervisor/supervisor.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import {
+  startSupervisor,
+  type ChildLabel,
+  type SupervisorHandle,
+} from "./supervisor.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = resolve(__dirname, "test-fixtures");
+const ECHO = resolve(FIXTURES, "echo-worker.mjs");
+const HANG = resolve(FIXTURES, "hang-worker.mjs");
+const CRASH = resolve(FIXTURES, "crash-worker.mjs");
+
+interface TestOpts {
+  pm?: string;
+  ws?: string;
+  shutdownTimeout?: number;
+  healthCheckInterval?: number;
+  healthCheckTimeout?: number;
+  maxRestarts?: number;
+  onFatal?: (label: ChildLabel, count: number) => void;
+}
+
+const handles: SupervisorHandle[] = [];
+
+function start(opts: TestOpts = {}): {
+  handle: SupervisorHandle;
+  terminated: ReturnType<typeof vi.fn>;
+} {
+  const terminated = vi.fn();
+  const handle = startSupervisor({
+    port: 0,
+    pmWorkerScript: opts.pm ?? ECHO,
+    wsServerChildScript: opts.ws ?? ECHO,
+    shutdownTimeout: opts.shutdownTimeout ?? 300,
+    ...(opts.healthCheckInterval !== undefined && {
+      healthCheckInterval: opts.healthCheckInterval,
+    }),
+    ...(opts.healthCheckTimeout !== undefined && {
+      healthCheckTimeout: opts.healthCheckTimeout,
+    }),
+    ...(opts.maxRestarts !== undefined && { maxRestarts: opts.maxRestarts }),
+    ...(opts.onFatal && { onFatal: opts.onFatal }),
+    onTerminate: terminated,
+    installGlobalHandlers: false,
+  });
+  handles.push(handle);
+  return { handle, terminated };
+}
+
+describe("startSupervisor", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    // Best-effort cleanup: stop any handles whose tests didn't already.
+    for (const handle of handles) {
+      try {
+        handle.stop();
+      } catch {
+        // already stopped
+      }
+    }
+    handles.length = 0;
+    // Give SIGKILL escalation a moment to actually reap children.
+    await sleep(500);
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it("calls onTerminate after a graceful stop with responsive children", async () => {
+    const { handle, terminated } = start({ shutdownTimeout: 400 });
+    await sleep(200); // wait for child:ready
+    handle.stop();
+    await sleep(700); // > shutdownTimeout
+    expect(terminated).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes stop() as an alias for shutdown()", async () => {
+    const { handle, terminated } = start({ shutdownTimeout: 300 });
+    await sleep(200);
+    expect(handle.shutdown).toBe(handle.stop);
+    handle.stop();
+    await sleep(500);
+    expect(terminated).toHaveBeenCalledTimes(1);
+  });
+
+  it("escalates to SIGKILL when children ignore the graceful shutdown signal", async () => {
+    const { handle, terminated } = start({
+      pm: HANG,
+      ws: HANG,
+      shutdownTimeout: 250,
+    });
+    await sleep(200);
+    handle.stop();
+    await sleep(600);
+    expect(terminated).toHaveBeenCalledTimes(1);
+    const sigkillLog = warnSpy.mock.calls.some((call) =>
+      String(call[0]).includes("graceful shutdown timed out"),
+    );
+    expect(sigkillLog).toBe(true);
+  });
+
+  it("kills the PM worker when it stops responding to health checks", async () => {
+    start({
+      pm: HANG,
+      ws: ECHO,
+      healthCheckInterval: 80,
+      healthCheckTimeout: 150,
+      shutdownTimeout: 200,
+    });
+    // 80ms interval + 150ms pong timeout → SIGKILL ~230ms after first ping.
+    await sleep(800);
+    const healthKillLog = warnSpy.mock.calls.some((call) =>
+      String(call[0]).includes("did not respond to health check"),
+    );
+    expect(healthKillLog).toBe(true);
+  });
+
+  it("invokes onFatal and shuts down once maxRestarts is exceeded", async () => {
+    const onFatal = vi.fn();
+    const { terminated } = start({
+      pm: CRASH,
+      ws: ECHO,
+      maxRestarts: 1,
+      onFatal,
+      shutdownTimeout: 200,
+    });
+    // CRASH worker: ready → exit(1) ~20ms after spawn.
+    // Cycle: spawn → exit → schedule restart (1s) → re-spawn → exit → fatal.
+    await sleep(2_000);
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    expect(onFatal.mock.calls[0]?.[0]).toBe("pm-worker");
+    await sleep(400);
+    expect(terminated).toHaveBeenCalledTimes(1);
+  }, 6_000);
+});

--- a/packages/server/src/supervisor/supervisor.ts
+++ b/packages/server/src/supervisor/supervisor.ts
@@ -8,7 +8,9 @@
  * Responsibilities:
  *   - Monitor child health and auto-restart on crash (exponential backoff)
  *   - Relay IPC messages between children (PM events → WS, WS commands → PM)
- *   - Graceful shutdown ordering (WS first, then PM)
+ *   - Graceful shutdown (IPC shutdown → SIGKILL after `shutdownTimeout`)
+ *   - Optional health check ping → SIGKILL hung children
+ *   - `maxRestarts` cap with `onFatal` escalation
  *
  * This implementation is generic: the concrete child scripts and the crash /
  * pre-restart hooks are supplied by the embedding application via
@@ -17,6 +19,7 @@
 import { fork, type ChildProcess, type Serializable } from "node:child_process";
 import type {
   IpcEvent,
+  IpcPingCommand,
   SupervisorToChild,
   ChildToSupervisor,
   IpcRequestStateDump,
@@ -31,12 +34,27 @@ const BASE_RESTART_DELAY_MS = 1_000;
 /** Minimum uptime before resetting backoff counter (ms). */
 const STABLE_UPTIME_MS = 60_000;
 
+/** Default graceful-shutdown timeout (ms). */
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000;
+
+/** Default health-check pong timeout (ms). */
+const DEFAULT_HEALTH_CHECK_TIMEOUT_MS = 5_000;
+
+/** Delay between WS shutdown signal and PM shutdown signal (ms). */
+const PM_SHUTDOWN_DELAY_MS = 2_000;
+
+/** Brief settle time between SIGKILL and onTerminate so kill takes effect. */
+const POST_KILL_SETTLE_MS = 100;
+
 interface ChildState {
   process: ChildProcess | null;
   restartCount: number;
   lastStartTime: number;
   shuttingDown: boolean;
 }
+
+/** Identifier for a supervised child, used in fatal callback and logs. */
+export type ChildLabel = "pm-worker" | "ws-server";
 
 export interface SupervisorOptions {
   /** Port the WS/API server should listen on. Exposed to children via `ENGINE_PORT`. */
@@ -57,11 +75,53 @@ export interface SupervisorOptions {
   onBeforeRestart?: () => Promise<void> | void;
   /** Extra env vars propagated to both children. Useful for app-specific config. */
   childEnv?: Record<string, string>;
+  /**
+   * Total time (ms) the graceful shutdown sequence is allowed to take before
+   * SIGKILL is sent to any still-alive children. Defaults to 5_000.
+   */
+  shutdownTimeout?: number;
+  /**
+   * Interval (ms) at which the supervisor pings the PM worker over IPC.
+   * If a `pong` is not received within `healthCheckTimeout`, the worker is
+   * SIGKILLed and restarted via the normal exit/restart path.
+   * Omit (or set to `undefined`) to disable health checks.
+   */
+  healthCheckInterval?: number;
+  /** Pong response timeout (ms) for health checks. Defaults to 5_000. */
+  healthCheckTimeout?: number;
+  /**
+   * Maximum number of restarts allowed per child before the supervisor gives
+   * up. The counter is reset whenever a child stays alive for at least
+   * {@link STABLE_UPTIME_MS}. Defaults to {@link Number.POSITIVE_INFINITY}
+   * (unbounded — preserves the legacy behaviour).
+   */
+  maxRestarts?: number;
+  /**
+   * Invoked when a child exceeds {@link SupervisorOptions.maxRestarts}. After
+   * the callback runs, the supervisor initiates its own shutdown sequence so
+   * the embedding process can exit cleanly.
+   */
+  onFatal?: (label: ChildLabel, restartCount: number) => void;
+  /**
+   * Called once the graceful shutdown sequence finishes. Defaults to
+   * `() => process.exit(0)`. Override (e.g. for tests) to keep the parent
+   * process alive after shutdown.
+   */
+  onTerminate?: () => void;
+  /**
+   * Whether to install `uncaughtException` / `unhandledRejection` / `SIGINT` /
+   * `SIGTERM` handlers on the supervisor process. Defaults to `true`. Set to
+   * `false` if the embedding application installs its own handlers (or in
+   * tests, to avoid contaminating the test runner process).
+   */
+  installGlobalHandlers?: boolean;
 }
 
 export interface SupervisorHandle {
-  /** Trigger a graceful shutdown (SIGTERM-equivalent). */
+  /** Trigger a graceful shutdown (IPC shutdown → SIGKILL fallback). */
   shutdown(signal?: string): void;
+  /** Alias for {@link SupervisorHandle.shutdown}. */
+  stop(signal?: string): void;
   /** Request a graceful restart of both children (re-fork after they exit). */
   restart(): void;
 }
@@ -71,7 +131,8 @@ export interface SupervisorHandle {
  * that can be used to drive graceful shutdown or a restart cycle.
  *
  * Installs `uncaughtException` / `unhandledRejection` / `SIGINT` / `SIGTERM`
- * handlers on `process` — do not call this more than once per process.
+ * handlers on `process` (unless `installGlobalHandlers: false`) — do not call
+ * this more than once per process when global handlers are installed.
  */
 export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
   const {
@@ -81,6 +142,13 @@ export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
     onCrash,
     onBeforeRestart,
     childEnv,
+    shutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT_MS,
+    healthCheckInterval,
+    healthCheckTimeout = DEFAULT_HEALTH_CHECK_TIMEOUT_MS,
+    maxRestarts = Number.POSITIVE_INFINITY,
+    onFatal,
+    onTerminate = () => process.exit(0),
+    installGlobalHandlers = true,
   } = options;
 
   const pmState: ChildState = {
@@ -99,12 +167,78 @@ export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
 
   let isShuttingDown = false;
   let isRestarting = false;
+  let terminated = false;
+
+  let healthCheckTimer: NodeJS.Timeout | null = null;
+  let pendingPingTimeout: NodeJS.Timeout | null = null;
 
   const baseEnv = {
     ...process.env,
     ENGINE_PORT: String(port),
     ...childEnv,
   };
+
+  function safeTerminate(): void {
+    if (terminated) return;
+    terminated = true;
+    try {
+      onTerminate();
+    } catch (err) {
+      console.error("[supervisor] onTerminate threw:", err);
+    }
+  }
+
+  function clearPendingPing(): void {
+    if (pendingPingTimeout) {
+      clearTimeout(pendingPingTimeout);
+      pendingPingTimeout = null;
+    }
+  }
+
+  function stopHealthCheck(): void {
+    if (healthCheckTimer) {
+      clearInterval(healthCheckTimer);
+      healthCheckTimer = null;
+    }
+    clearPendingPing();
+  }
+
+  function sendHealthPing(): void {
+    const child = pmState.process;
+    if (!child?.connected) return;
+    if (pmState.shuttingDown || isShuttingDown) return;
+    // Only one ping in flight at a time — if pong is overdue, the previous
+    // pendingPingTimeout is already scheduled to kill the worker.
+    if (pendingPingTimeout) return;
+
+    const ping: IpcPingCommand = { type: "ping" };
+    try {
+      child.send(ping);
+    } catch {
+      // IPC closed — exit handler will fire and restart
+      return;
+    }
+
+    pendingPingTimeout = setTimeout(() => {
+      pendingPingTimeout = null;
+      if (isShuttingDown || pmState.shuttingDown) return;
+      if (child !== pmState.process) return; // worker already replaced
+      console.warn(
+        "[supervisor] PM worker did not respond to health check — SIGKILL",
+      );
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // already dead — exit handler will run
+      }
+    }, healthCheckTimeout);
+  }
+
+  function startHealthCheck(): void {
+    if (!healthCheckInterval || healthCheckInterval <= 0) return;
+    if (healthCheckTimer) return;
+    healthCheckTimer = setInterval(sendHealthPing, healthCheckInterval);
+  }
 
   function forkPmWorker(): ChildProcess {
     const child = fork(pmWorkerScript, [], {
@@ -118,6 +252,13 @@ export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
       const typed = msg as IpcEvent | ChildToSupervisor;
       if (typed.type === "child:ready") {
         console.log("[supervisor] PM worker ready");
+        startHealthCheck();
+        return;
+      }
+      // Consume pong only if it answers our pending health-check ping.
+      // Otherwise, fall through to the relay so a WS-initiated ping can pass.
+      if (typed.type === "pong" && pendingPingTimeout) {
+        clearPendingPing();
         return;
       }
       // Relay PM events to WS child
@@ -135,8 +276,9 @@ export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
         `[supervisor] PM worker exited (code=${code}, signal=${signal})`,
       );
       pmState.process = null;
+      clearPendingPing();
       if (!isShuttingDown && !pmState.shuttingDown) {
-        scheduleRestart(pmState, forkPmWorker, "PM worker");
+        scheduleRestart(pmState, forkPmWorker, "pm-worker");
       }
     });
 
@@ -191,7 +333,7 @@ export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
       );
       wsState.process = null;
       if (!isShuttingDown && !wsState.shuttingDown) {
-        scheduleRestart(wsState, forkWsChild, "WS server");
+        scheduleRestart(wsState, forkWsChild, "ws-server");
       }
     });
 
@@ -205,12 +347,25 @@ export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
   function scheduleRestart(
     state: ChildState,
     forkFn: () => ChildProcess,
-    label: string,
+    label: ChildLabel,
   ): void {
     const uptime = Date.now() - state.lastStartTime;
 
     if (uptime >= STABLE_UPTIME_MS) {
       state.restartCount = 0;
+    }
+
+    if (state.restartCount >= maxRestarts) {
+      console.error(
+        `[supervisor] ${label} exceeded maxRestarts (${maxRestarts}) — escalating to fatal`,
+      );
+      try {
+        onFatal?.(label, state.restartCount);
+      } catch (err) {
+        console.error("[supervisor] onFatal threw:", err);
+      }
+      shutdown("fatal");
+      return;
     }
 
     const delay = Math.min(
@@ -230,6 +385,26 @@ export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
     }, delay);
   }
 
+  /** Send IPC graceful-shutdown to a child; fall back to SIGTERM if IPC fails. */
+  function sendShutdownOrSigterm(
+    child: ChildProcess,
+    msg: SupervisorToChild,
+  ): void {
+    if (child.connected) {
+      try {
+        child.send(msg);
+        return;
+      } catch {
+        // fall through
+      }
+    }
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // already dead
+    }
+  }
+
   async function gracefulRestart(): Promise<void> {
     if (isRestarting || isShuttingDown) return;
     isRestarting = true;
@@ -244,6 +419,9 @@ export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
         console.error("[supervisor] onBeforeRestart hook failed:", err);
       }
     }
+
+    // Pause health check during restart so we don't kill mid-restart.
+    stopHealthCheck();
 
     const shutdownMsg: SupervisorToChild = { type: "supervisor:shutdown" };
 
@@ -272,11 +450,7 @@ export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
         wsExited = true;
         tryRefork();
       });
-      try {
-        wsChild.send(shutdownMsg);
-      } catch {
-        wsChild.kill("SIGTERM");
-      }
+      sendShutdownOrSigterm(wsChild, shutdownMsg);
     } else {
       wsExited = true;
     }
@@ -289,11 +463,7 @@ export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
           pmExited = true;
           tryRefork();
         });
-        try {
-          pmChild.send(shutdownMsg);
-        } catch {
-          pmChild.kill("SIGTERM");
-        }
+        sendShutdownOrSigterm(pmChild, shutdownMsg);
       } else {
         pmExited = true;
         tryRefork();
@@ -311,8 +481,8 @@ export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
           pmExited = true;
           tryRefork();
         }
-      }, 5_000);
-    }, 2_000);
+      }, shutdownTimeout);
+    }, Math.min(PM_SHUTDOWN_DELAY_MS, Math.max(0, shutdownTimeout - 100)));
   }
 
   function shutdown(signal = "shutdown"): void {
@@ -320,48 +490,66 @@ export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
     isShuttingDown = true;
     console.log(`[supervisor] ${signal} received — shutting down children`);
 
+    stopHealthCheck();
+
     const shutdownMsg: SupervisorToChild = { type: "supervisor:shutdown" };
 
-    if (wsState.process?.connected) {
+    // 1. Tell WS to start cleanup. It can wind down independently.
+    if (wsState.process) {
       wsState.shuttingDown = true;
-      try {
-        wsState.process.send(shutdownMsg);
-      } catch {
-        wsState.process.kill("SIGTERM");
-      }
+      sendShutdownOrSigterm(wsState.process, shutdownMsg);
     }
 
+    // 2. Tell PM to start cleanup after a short delay so WS gets a head start
+    //    (PM may still be needed to kill in-flight CLIs while WS finishes).
+    const pmDelay = Math.min(
+      PM_SHUTDOWN_DELAY_MS,
+      Math.max(0, shutdownTimeout - 100),
+    );
     setTimeout(() => {
-      if (pmState.process?.connected) {
+      if (pmState.process) {
         pmState.shuttingDown = true;
-        try {
-          pmState.process.send(shutdownMsg);
-        } catch {
-          pmState.process.kill("SIGTERM");
+        sendShutdownOrSigterm(pmState.process, shutdownMsg);
+      }
+    }, pmDelay);
+
+    // 3. After shutdownTimeout: SIGKILL anyone still alive, then terminate.
+    setTimeout(() => {
+      let killed = false;
+      for (const state of [wsState, pmState]) {
+        if (state.process) {
+          console.warn(
+            `[supervisor] SIGKILL child pid=${state.process.pid} (graceful shutdown timed out)`,
+          );
+          try {
+            state.process.kill("SIGKILL");
+            killed = true;
+          } catch {
+            // already dead
+          }
         }
       }
-
-      setTimeout(() => {
-        console.log("[supervisor] Force exit");
-        process.exit(0);
-      }, 5_000);
-    }, 2_000);
+      // Brief settle so the SIGKILL takes effect before we hand control back
+      setTimeout(safeTerminate, killed ? POST_KILL_SETTLE_MS : 0);
+    }, shutdownTimeout);
   }
 
-  process.on("uncaughtException", (err) => {
-    console.error("[supervisor] Uncaught exception:", err);
-    onCrash?.(err, "supervisor:uncaughtException");
-    shutdown("uncaughtException");
-  });
+  if (installGlobalHandlers) {
+    process.on("uncaughtException", (err) => {
+      console.error("[supervisor] Uncaught exception:", err);
+      onCrash?.(err, "supervisor:uncaughtException");
+      shutdown("uncaughtException");
+    });
 
-  process.on("unhandledRejection", (reason) => {
-    console.error("[supervisor] Unhandled rejection:", reason);
-    onCrash?.(reason, "supervisor:unhandledRejection");
-    shutdown("unhandledRejection");
-  });
+    process.on("unhandledRejection", (reason) => {
+      console.error("[supervisor] Unhandled rejection:", reason);
+      onCrash?.(reason, "supervisor:unhandledRejection");
+      shutdown("unhandledRejection");
+    });
 
-  process.on("SIGINT", () => shutdown("SIGINT"));
-  process.on("SIGTERM", () => shutdown("SIGTERM"));
+    process.on("SIGINT", () => shutdown("SIGINT"));
+    process.on("SIGTERM", () => shutdown("SIGTERM"));
+  }
 
   console.log(`[supervisor] Starting synapse-chat server (port ${port})`);
 
@@ -373,6 +561,7 @@ export function startSupervisor(options: SupervisorOptions): SupervisorHandle {
 
   return {
     shutdown,
+    stop: shutdown,
     restart: gracefulRestart,
   };
 }

--- a/packages/server/src/supervisor/test-fixtures/crash-worker.mjs
+++ b/packages/server/src/supervisor/test-fixtures/crash-worker.mjs
@@ -1,0 +1,4 @@
+// Test fixture: signals ready, then exits with code 1 after a tick.
+// Used to test restart backoff and maxRestarts → onFatal escalation.
+process.send({ type: "child:ready" });
+setTimeout(() => process.exit(1), 20);

--- a/packages/server/src/supervisor/test-fixtures/echo-worker.mjs
+++ b/packages/server/src/supervisor/test-fixtures/echo-worker.mjs
@@ -1,0 +1,18 @@
+// Test fixture: responds to ping with pong, exits on supervisor:shutdown.
+process.on("message", (msg) => {
+  if (!msg || typeof msg !== "object") return;
+  if (msg.type === "supervisor:shutdown") {
+    process.exit(0);
+  } else if (msg.type === "ping") {
+    try {
+      process.send({ type: "pong" });
+    } catch {
+      // ignore
+    }
+  }
+});
+
+process.send({ type: "child:ready" });
+
+// Keep alive
+setInterval(() => {}, 60_000);

--- a/packages/server/src/supervisor/test-fixtures/hang-worker.mjs
+++ b/packages/server/src/supervisor/test-fixtures/hang-worker.mjs
@@ -1,0 +1,15 @@
+// Test fixture: ignores all IPC messages (does NOT respond to ping or shutdown).
+// Also ignores SIGTERM. Used to test:
+//   - health check timeout → SIGKILL
+//   - shutdownTimeout → SIGKILL
+process.on("message", () => {
+  // intentionally ignore
+});
+process.on("SIGTERM", () => {
+  // intentionally ignore
+});
+
+process.send({ type: "child:ready" });
+
+// Keep alive
+setInterval(() => {}, 60_000);


### PR DESCRIPTION
## Summary

`startSupervisor()` にグレースフル停止 / PM worker health check / restart 上限を追加する（`@synapse-chat/server` minor bump）。

- 既存 API は完全に後方互換。新オプションはすべて optional で、未指定時は従来挙動を維持
- ハングした PM worker を ping/pong で検出 → SIGKILL → 自動 restart
- `maxRestarts` 超過時に `onFatal` callback で通知、supervisor 自身も graceful 停止

Closes #6

## Changes

- `SupervisorOptions` 拡張: `shutdownTimeout` / `healthCheckInterval` / `healthCheckTimeout` / `maxRestarts` / `onFatal` / `onTerminate` / `installGlobalHandlers`
- `SupervisorHandle` に `stop()` を追加（`shutdown()` のエイリアス）
- `shutdown()` シーケンスを「IPC `supervisor:shutdown` → `shutdownTimeout` 経過後 SIGKILL → `onTerminate`」に整理
- PM worker への `ping` / `pong` 健全性チェック（WS 子は consumer 提供のため対象外）
- vitest 統合テスト + fixture worker（echo / hang / crash）
- README に新オプションの使用例を追記
- changeset (`@synapse-chat/server` minor) を追加

## Test plan

- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass
- [x] `pnpm --filter @synapse-chat/server test` — 116/116 pass（うち supervisor 統合 5 件）
- [x] `pnpm --filter @synapse-chat/server build` — pass
- [x] `pnpm test` (repo-wide) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)