### PR TITLE
feat(react): expose WSClient from useChat to prevent duplicate sockets

### DIFF
--- a/.changeset/expose-client-from-usechat.md
+++ b/.changeset/expose-client-from-usechat.md
@@ -1,0 +1,14 @@
+---
+"@synapse-chat/react": minor
+---
+
+feat(react): expose underlying `WSClient` from `useChat`
+
+`useChat` now returns a `client` field — the same `WSClient` instance the hook uses internally. Use it to send arbitrary control messages (e.g. `{ type: "app:reset" }`) without spinning up a second `useWebSocket`, which would open a duplicate socket from the same component.
+
+```tsx
+const { sendMessage, messages, client } = useChat({ wsOptions: { url } });
+const reset = () => client.send({ type: "app:reset" });
+```
+
+The `UseChatResult` type is now generic over `<TServer, TClient>` to type the exposed `client`. Existing call sites that don't reference `client` are unaffected.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -84,6 +84,41 @@ to surface specific system subtypes (e.g. status badges, log entries) pass a
 />
 ```
 
+## Pitfalls
+
+### Don't pair `useChat` with a separate `useWebSocket` for the same URL
+
+`useChat` already calls `useWebSocket` internally. Each `useWebSocket`
+instantiates its own `WSClient`, so this opens **two** sockets to the same
+server from a single component:
+
+```tsx
+// ❌ Two sockets — useChat + useWebSocket each create a WSClient
+function App() {
+  const { sendMessage, messages } = useChat({ wsOptions: { url } });
+  const { send } = useWebSocket({ url }); // ← second connection
+  // ...
+}
+```
+
+If you need to send arbitrary client messages (control frames like
+`{ type: "app:reset" }`, custom commands, etc.) alongside chat traffic, use
+the `client` returned by `useChat`:
+
+```tsx
+// ✅ One socket — reuse the client useChat already owns
+function App() {
+  const { sendMessage, messages, client } = useChat({ wsOptions: { url } });
+
+  const reset = () => client.send({ type: "app:reset" });
+  // ...
+}
+```
+
+`client` is the same `WSClient` instance `useChat` uses internally and is
+stable across renders, so you can also call `client.onMessage(...)` to
+subscribe to raw frames `decode` chose to ignore.
+
 ## License
 
 MIT

--- a/packages/react/src/hooks/useChat.test.tsx
+++ b/packages/react/src/hooks/useChat.test.tsx
@@ -23,22 +23,29 @@ function makeFakeClient(): FakeClient {
   };
 }
 
-// Hoisted so the `vi.mock` factory can see it.
+// Hoisted so the `vi.mock` factory can see it. The `client` object is created
+// once and reused across calls to mirror useWebSocket's `useRef` semantics —
+// consumers rely on `client` being referentially stable across renders.
 const fakeClient = vi.hoisted(() => {
   const handlers = new Set<(raw: unknown) => void>();
+  const onMessage = (h: (raw: unknown) => void) => {
+    handlers.add(h);
+    return () => handlers.delete(h);
+  };
+  const clientSend = vi.fn();
+  const client = { onMessage, send: clientSend };
   return {
     handlers,
-    onMessage: (h: (raw: unknown) => void) => {
-      handlers.add(h);
-      return () => handlers.delete(h);
-    },
+    onMessage,
     send: vi.fn(),
+    clientSend,
+    client,
   };
 });
 
 vi.mock("./useWebSocket.js", () => ({
   useWebSocket: () => ({
-    client: { onMessage: fakeClient.onMessage },
+    client: fakeClient.client,
     isConnected: true,
     send: fakeClient.send,
   }),
@@ -48,6 +55,7 @@ afterEach(() => {
   cleanup();
   fakeClient.handlers.clear();
   fakeClient.send.mockReset();
+  fakeClient.clientSend.mockReset();
 });
 
 const wsOptions = { url: "ws://test" };
@@ -202,6 +210,33 @@ describe("useChat — storage integration", () => {
     const { result } = renderHook(() => useChat({ wsOptions, decode, storage }));
     expect(result.current.isHydrating).toBe(false);
     expect(load).not.toHaveBeenCalled();
+  });
+});
+
+describe("useChat — client exposure (issue #8)", () => {
+  it("exposes the underlying WSClient on the result", () => {
+    const { result } = renderHook(() => useChat({ wsOptions, decode }));
+    expect(result.current.client).toBeDefined();
+    expect(typeof result.current.client.send).toBe("function");
+  });
+
+  it("returns a stable client across re-renders", () => {
+    const { result, rerender } = renderHook(() =>
+      useChat({ wsOptions, decode }),
+    );
+    const first = result.current.client;
+    rerender();
+    expect(result.current.client).toBe(first);
+  });
+
+  it("forwards arbitrary messages through client.send without re-encoding", () => {
+    const { result } = renderHook(() => useChat({ wsOptions, decode }));
+    const raw = { type: "app:reset" };
+    act(() => {
+      result.current.client.send(raw);
+    });
+    expect(fakeClient.clientSend).toHaveBeenCalledWith(raw);
+    expect(fakeClient.send).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/react/src/hooks/useChat.ts
+++ b/packages/react/src/hooks/useChat.ts
@@ -11,7 +11,7 @@ import type {
   ImageAttachment,
   StreamMessage,
 } from "@synapse-chat/core";
-import type { WSClientOptions } from "../lib/ws-client.js";
+import type { WSClient, WSClientOptions } from "../lib/ws-client.js";
 import { useWebSocket } from "./useWebSocket.js";
 
 export interface UseChatOptions<TServer = unknown, TClient = unknown> {
@@ -49,7 +49,7 @@ export interface UseChatOptions<TServer = unknown, TClient = unknown> {
   saveDebounceMs?: number;
 }
 
-export interface UseChatResult {
+export interface UseChatResult<TServer = unknown, TClient = unknown> {
   /** Messages in display order. */
   messages: StreamMessage[];
   /** Replace the message list wholesale (e.g. to load history). */
@@ -67,6 +67,13 @@ export interface UseChatResult {
    * `false` when no storage/sessionId is configured.
    */
   isHydrating: boolean;
+  /**
+   * The underlying {@link WSClient}. Stable across renders. Use this to send
+   * arbitrary client messages (e.g. control frames like `{ type: "app:reset" }`)
+   * without spinning up a second `useWebSocket` — which would open a second
+   * socket, since each `useWebSocket` instantiates its own client.
+   */
+  client: WSClient<TServer, TClient>;
 }
 
 function defaultEncode<TClient>(text: string, images?: ImageAttachment[]): TClient {
@@ -94,7 +101,7 @@ function defaultEncode<TClient>(text: string, images?: ImageAttachment[]): TClie
  */
 export function useChat<TServer = unknown, TClient = unknown>(
   options: UseChatOptions<TServer, TClient>,
-): UseChatResult {
+): UseChatResult<TServer, TClient> {
   const {
     wsOptions,
     decode,
@@ -197,5 +204,6 @@ export function useChat<TServer = unknown, TClient = unknown>(
     sendMessage,
     isConnected,
     isHydrating,
+    client,
   };
 }


### PR DESCRIPTION
## Summary

`useChat` now returns the underlying `WSClient` so callers can send arbitrary
control frames (e.g. `{ type: "app:reset" }`) without spinning up a second
`useWebSocket` — which would open a duplicate socket from the same component.

## Changes

- `packages/react/src/hooks/useChat.ts` — `UseChatResult` gets a new `client` field; the type is now generic over `<TServer, TClient>` so the exposed client is properly typed.
- `packages/react/src/hooks/useChat.test.tsx` — adds tests verifying `client` is exposed, stable across renders, and forwards arbitrary messages without re-encoding. Mock updated to memoize `client` so it mirrors `useWebSocket`'s `useRef` semantics.
- `packages/react/README.md` — adds a `## Pitfalls` section documenting the dual-socket trap and the `client` workaround.
- `.changeset/expose-client-from-usechat.md` — `@synapse-chat/react` minor.

Existing call sites that don't reference `client` are unaffected (additive change to the result type).

Closes #8

## Test plan

- [x] `pnpm --filter @synapse-chat/react test` — 69 passed (10 files)
- [x] `pnpm typecheck` — clean across all 5 workspace projects
- [x] `pnpm lint` — clean
- [x] `pnpm build` — all packages + example app build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)