### PR TITLE
chore: gitignore vibe-admiral / Claude Code Engine 注入ファイル

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,11 @@ coverage/
 .env
 .env.*
 !.env.example
+
+# vibe-admiral / Claude Code Engine が注入する transient ファイル
+.claude/skills/*/
+.claude/rules/
+.claude/workflow-state.json
+.claude/ship-log.jsonl
+.claude/escort-log.jsonl
+.claude/.escort-stash/


### PR DESCRIPTION
vibe-admiral の Engine が worktree に注入する transient ファイル (- .claude/skills/*/
- .claude/rules/
- workflow-state.json
- ship-log.jsonl
- escort-log.jsonl
- .escort-stash/) を .gitignore に追加します。

利用者の独自 skill は `!.claude/skills/my-skill/` で whitelist 可能です。

参考: vibe-admiral 本体の .gitignore (同じ policy)。