### PR TITLE
fix: allow document files (csv, md, txt, pdf) in file attachment dialog

### DIFF
--- a/packages/react/src/components/SessionInput.tsx
+++ b/packages/react/src/components/SessionInput.tsx
@@ -17,6 +17,14 @@ const ACCEPTED_TYPES = new Set<string>([
   "image/jpeg",
   "image/gif",
   "image/webp",
+  "text/plain",
+  "text/csv",
+  "text/markdown",
+  "application/pdf",
+  "application/json",
+  "application/yaml",
+  "text/yaml",
+  "text/x-yaml",
 ]);
 
 type ImageMediaType = ImageAttachment["mediaType"];
@@ -271,7 +279,7 @@ export function SessionInput({
         <input
           ref={fileInputRef}
           type="file"
-          accept="image/png,image/jpeg,image/gif,image/webp"
+          accept="image/*,text/*,.csv,.md,.txt,.pdf,.json,.yaml,.yml"
           multiple
           className="hidden"
           onChange={handleFileChange}


### PR DESCRIPTION
Closes mizunowanko/agents-familia#181

Expanded `accept` attribute and `ACCEPTED_TYPES` to include text/* and document formats so users can attach CSV, Markdown, JSON, YAML, and PDF files in addition to images.