### PR TITLE
fix: expand assistant message bubble to full pane width

### DIFF
--- a/packages/react/src/components/ChatMessage.tsx
+++ b/packages/react/src/components/ChatMessage.tsx
@@ -180,7 +180,8 @@ export const ChatMessage = memo(function ChatMessage({
     >
       <div
         className={cn(
-          "max-w-[80%] rounded-lg px-3 py-2 text-sm",
+          "rounded-lg px-3 py-2 text-sm",
+          isRightAligned ? "max-w-[80%]" : "w-full",
           isUser || isAssistantOnRight
             ? "bg-primary text-primary-foreground"
             : isError


### PR DESCRIPTION
Fixes the right-side whitespace on assistant message bubbles in agents-familia.

## Changes
- `ChatMessage.tsx`: `max-w-[80%]` is now applied only to right-aligned (user) messages; assistant messages use `w-full` to fill available pane width

Closes mizunowanko/agents-familia#187

🤖 Generated with [Claude Code](https://claude.com/claude-code)