### PR TITLE
feat(react): CompactionBadge — コンパクション可視化コンポーネントの追加

### DIFF
--- a/.changeset/compaction-badge.md
+++ b/.changeset/compaction-badge.md
@@ -1,0 +1,9 @@
+---
+"@synapse-chat/react": minor
+---
+
+feat(react): add CompactionBadge component and auto-render on compaction system messages
+
+- New `CompactionBadge` component exported from `@synapse-chat/react` with animate-pulse violet styling
+- `ChatMessage` now auto-renders `CompactionBadge` when `message.subtype` is `"compact-status"` or `"compacting"`
+- Existing `renderSystem` prop continues to override the default behavior

--- a/packages/react/src/components/ChatMessage.test.tsx
+++ b/packages/react/src/components/ChatMessage.test.tsx
@@ -35,6 +35,34 @@ describe("<ChatMessage />", () => {
     expect(screen.getByTestId("status")).toHaveTextContent("OK");
   });
 
+  it("renders CompactionBadge for compact-status subtype", () => {
+    render(
+      <ChatMessage
+        message={{ type: "system", subtype: "compact-status", content: "Compacting context..." }}
+      />,
+    );
+    expect(screen.getByText("Compacting context…")).toBeInTheDocument();
+  });
+
+  it("renders CompactionBadge for compacting subtype", () => {
+    render(
+      <ChatMessage
+        message={{ type: "system", subtype: "compacting", content: "" }}
+      />,
+    );
+    expect(screen.getByText("Compacting context…")).toBeInTheDocument();
+  });
+
+  it("renderSystem overrides CompactionBadge when provided", () => {
+    const { container } = render(
+      <ChatMessage
+        message={{ type: "system", subtype: "compact-status", content: "x" }}
+        renderSystem={() => null}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it("delegates meta rendering when renderMeta returns a node", () => {
     render(
       <ChatMessage

--- a/packages/react/src/components/ChatMessage.tsx
+++ b/packages/react/src/components/ChatMessage.tsx
@@ -13,6 +13,7 @@ import type { ImageAttachment, StreamMessage } from "@synapse-chat/core";
 import { cn, isSafeUrl } from "../lib/utils.js";
 import { formatTime } from "../lib/format-time.js";
 import { remarkIssueLink } from "../lib/remark-issue-link.js";
+import { CompactionBadge } from "./CompactionBadge.js";
 
 /** Convert base64 ImageAttachments to object URLs, revoking on cleanup. */
 function useImageObjectUrls(images: ImageAttachment[] | undefined): string[] {
@@ -165,6 +166,9 @@ export const ChatMessage = memo(function ChatMessage({
     if (renderSystem) {
       const rendered = renderSystem(message);
       return rendered === null || rendered === undefined ? null : <>{rendered}</>;
+    }
+    if (message.subtype === "compact-status" || message.subtype === "compacting") {
+      return <CompactionBadge />;
     }
     return null;
   }

--- a/packages/react/src/components/CompactionBadge.tsx
+++ b/packages/react/src/components/CompactionBadge.tsx
@@ -1,0 +1,20 @@
+import type { ReactElement } from "react";
+import { cn } from "../lib/utils.js";
+
+export interface CompactionBadgeProps {
+  className?: string;
+}
+
+export function CompactionBadge({ className }: CompactionBadgeProps): ReactElement {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 px-3 py-2 text-sm text-violet-400/80",
+        className,
+      )}
+    >
+      <span className="inline-block h-2 w-2 rounded-full bg-violet-400 animate-pulse" />
+      <span>Compacting context…</span>
+    </div>
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,10 @@ export {
   type ChatMessageProps,
 } from "./components/ChatMessage.js";
 export {
+  CompactionBadge,
+  type CompactionBadgeProps,
+} from "./components/CompactionBadge.js";
+export {
   ToolUseGroup,
   type ToolUseGroupProps,
 } from "./components/ToolUseGroup.js";


### PR DESCRIPTION
## Summary

Claude CLI のコンテキスト圧縮（compaction）を視覚化する `CompactionBadge` コンポーネントを追加。

## Changes

- **NEW** `packages/react/src/components/CompactionBadge.tsx` — アニメーション付きパルスインジケーター（Tailwind `animate-pulse`）+ バイオレット系スタイリング
- **MODIFY** `packages/react/src/components/ChatMessage.tsx` — `message.subtype === "compact-status"` または `"compacting"` を検出して `CompactionBadge` を自動レンダリング。`renderSystem` prop による上書き可能
- **MODIFY** `packages/react/src/index.ts` — `CompactionBadge` / `CompactionBadgeProps` を export
- **NEW** `.changeset/compaction-badge.md` — `@synapse-chat/react` minor changeset

Closes #21

## Test plan

- `pnpm typecheck` — TypeScript 型チェック pass ✅
- `pnpm test` — 全テスト pass（88 tests in 12 files for react package）✅
- `ChatMessage.test.tsx` に 3 ケース追加: compact-status 検出、compacting 検出、renderSystem 上書き

🤖 Generated with [Claude Code](https://claude.com/claude-code)