### PR TITLE
feat(react): デフォルト Markdown CSS スタイルの同梱 (./styles サブパス)

### DIFF
--- a/.changeset/react-markdown-css-styles.md
+++ b/.changeset/react-markdown-css-styles.md
@@ -1,0 +1,17 @@
+---
+"@synapse-chat/react": minor
+---
+
+Add default Markdown CSS styles via `@synapse-chat/react/styles` subpath export.
+
+Consumers can opt in by importing:
+
+```typescript
+import "@synapse-chat/react/styles";
+```
+
+The stylesheet styles `.synapse-chat-markdown` elements (tables, code blocks, blockquotes, lists, headings) and exposes CSS custom properties for theming:
+
+- `--synapse-chat-border` (default: `#e2e8f0`)
+- `--synapse-chat-code-bg` (default: `#f8fafc`)
+- `--synapse-chat-muted` (default: `#64748b`)

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -34,13 +34,22 @@ const WS_OPTIONS: WSClientOptions<ServerMessage, ClientMessage> = {
   pongMessage: { type: "pong" },
 };
 
+// Static demo messages shown before a real session starts.
+const DEMO_MESSAGES: StreamMessage[] = [
+  {
+    type: "assistant",
+    content:
+      "## Markdown スタイルデモ\n\n`@synapse-chat/react/styles` を import すると以下のスタイルが適用されます。\n\n### テーブル\n\n| パッケージ | バージョン | 用途 |\n|------------|-----------|------|\n| `react-markdown` | ^10 | Markdown → HTML 変換 |\n| `remark-gfm` | ^4 | GFM 拡張（テーブル等）|\n| `@synapse-chat/react` | 0.x | このライブラリ |\n\n### コードブロック\n\n```typescript\nimport \"@synapse-chat/react/styles\";\nimport { ChatMessage } from \"@synapse-chat/react\";\n```\n\n### Blockquote\n\n> CSS カスタムプロパティ（`--synapse-chat-border` 等）を上書きするだけでテーマをカスタマイズできます。\n\n### リスト\n\n- テーブル罫線\n- コードブロック背景\n- Blockquote 左ボーダー\n- リストスタイル",
+  },
+];
+
 /* ────────────────────────────────────────────────────────────────────────── */
 /* App                                                                        */
 /* ────────────────────────────────────────────────────────────────────────── */
 
 export function App() {
   const [draft, setDraft] = useState("");
-  const [messages, setMessages] = useState<StreamMessage[]>([]);
+  const [messages, setMessages] = useState<StreamMessage[]>(DEMO_MESSAGES);
   const [statusBanner, setStatusBanner] = useState<string | null>(null);
 
   const { client, isConnected, send } = useWebSocket(WS_OPTIONS);
@@ -136,7 +145,7 @@ export function App() {
 
       <main className="flex-1 overflow-y-auto px-4 py-6">
         <div className="mx-auto flex max-w-3xl flex-col gap-3">
-          {groups.length === 0 && (
+          {messages.length === 0 && (
             <p className="text-sm text-muted-foreground">
               Type a message below to start a Claude CLI session. The server
               will spawn <code>claude</code> on first send.

--- a/apps/example/src/main.tsx
+++ b/apps/example/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App.js";
 import "./index.css";
+import "@synapse-chat/react/styles";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("#root missing from index.html");

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,6 +23,9 @@
     "./storage": {
       "types": "./dist/storage/index.d.ts",
       "default": "./dist/storage/index.js"
+    },
+    "./styles": {
+      "default": "./dist/styles/chat-message.css"
     }
   },
   "files": [
@@ -32,9 +35,9 @@
     "!src/**/*.test.tsx",
     "!src/test-setup.ts"
   ],
-  "sideEffects": false,
+  "sideEffects": ["**/*.css"],
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc -b && mkdir -p dist/styles && cp src/styles/chat-message.css dist/styles/",
     "clean": "rm -rf dist *.tsbuildinfo",
     "typecheck": "tsc -b",
     "test": "vitest run"

--- a/packages/react/src/styles/chat-message.css
+++ b/packages/react/src/styles/chat-message.css
@@ -1,0 +1,143 @@
+:root {
+  --synapse-chat-border: #e2e8f0;
+  --synapse-chat-code-bg: #f8fafc;
+  --synapse-chat-muted: #64748b;
+}
+
+.synapse-chat-markdown {
+  line-height: 1.6;
+}
+
+/* Headings */
+.synapse-chat-markdown h1,
+.synapse-chat-markdown h2,
+.synapse-chat-markdown h3,
+.synapse-chat-markdown h4,
+.synapse-chat-markdown h5,
+.synapse-chat-markdown h6 {
+  margin-top: 1em;
+  margin-bottom: 0.5em;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.synapse-chat-markdown h1 { font-size: 1.5em; }
+.synapse-chat-markdown h2 { font-size: 1.25em; }
+.synapse-chat-markdown h3 { font-size: 1.125em; }
+
+/* Paragraphs */
+.synapse-chat-markdown p {
+  margin-top: 0;
+  margin-bottom: 0.75em;
+}
+
+.synapse-chat-markdown p:last-child {
+  margin-bottom: 0;
+}
+
+/* Lists */
+.synapse-chat-markdown ul,
+.synapse-chat-markdown ol {
+  margin-top: 0;
+  margin-bottom: 0.75em;
+  padding-left: 1.5em;
+}
+
+.synapse-chat-markdown ul {
+  list-style-type: disc;
+}
+
+.synapse-chat-markdown ol {
+  list-style-type: decimal;
+}
+
+.synapse-chat-markdown li {
+  margin-bottom: 0.25em;
+}
+
+.synapse-chat-markdown li > ul,
+.synapse-chat-markdown li > ol {
+  margin-top: 0.25em;
+  margin-bottom: 0;
+}
+
+/* Tables */
+.synapse-chat-markdown table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1em;
+  font-size: 0.9em;
+}
+
+.synapse-chat-markdown th,
+.synapse-chat-markdown td {
+  padding: 0.5em 0.75em;
+  border: 1px solid var(--synapse-chat-border);
+  text-align: left;
+}
+
+.synapse-chat-markdown th {
+  font-weight: 600;
+  background-color: var(--synapse-chat-code-bg);
+}
+
+.synapse-chat-markdown tr:nth-child(even) td {
+  background-color: color-mix(in srgb, var(--synapse-chat-code-bg) 50%, transparent);
+}
+
+/* Code */
+.synapse-chat-markdown code {
+  padding: 0.15em 0.35em;
+  border-radius: 0.25em;
+  background-color: var(--synapse-chat-code-bg);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.875em;
+}
+
+.synapse-chat-markdown pre {
+  margin-top: 0;
+  margin-bottom: 0.75em;
+  padding: 0.75em 1em;
+  overflow-x: auto;
+  border-radius: 0.375em;
+  background-color: var(--synapse-chat-code-bg);
+  border: 1px solid var(--synapse-chat-border);
+}
+
+.synapse-chat-markdown pre code {
+  padding: 0;
+  background-color: transparent;
+  border-radius: 0;
+  font-size: 0.875em;
+}
+
+/* Blockquotes */
+.synapse-chat-markdown blockquote {
+  margin: 0 0 0.75em;
+  padding: 0.25em 0.75em;
+  border-left: 3px solid var(--synapse-chat-border);
+  color: var(--synapse-chat-muted);
+}
+
+.synapse-chat-markdown blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+/* Horizontal rule */
+.synapse-chat-markdown hr {
+  margin: 1em 0;
+  border: none;
+  border-top: 1px solid var(--synapse-chat-border);
+}
+
+/* Links */
+.synapse-chat-markdown a {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* Task lists (remark-gfm) */
+.synapse-chat-markdown input[type="checkbox"] {
+  margin-right: 0.4em;
+  vertical-align: middle;
+}


### PR DESCRIPTION
## Summary

`@synapse-chat/react` に Markdown CSS スタイルを同梱し、`@synapse-chat/react/styles` で opt-in import できるようにする。

## Changes

- `packages/react/src/styles/chat-message.css` を新規追加
  - `.synapse-chat-markdown` 配下にテーブル・コードブロック・blockquote・リスト・見出しのスタイルを定義
  - CSS カスタムプロパティ（`--synapse-chat-border`, `--synapse-chat-code-bg`, `--synapse-chat-muted`）でテーマカスタマイズを可能にする
- `packages/react/package.json` を更新
  - `"./styles"` サブパスエクスポートを追加（`dist/styles/chat-message.css` を指す）
  - build スクリプトに CSS コピーステップを追加（`cp src/styles/chat-message.css dist/styles/`）
  - `sideEffects` を `["**/*.css"]` に更新（バンドラーが CSS を tree-shake しないよう）
- `apps/example/src/main.tsx` に `import "@synapse-chat/react/styles"` を追加
- `apps/example/src/App.tsx` にテーブル・コード・blockquote・リストを含む Markdown デモメッセージを追加
- `.changeset/react-markdown-css-styles.md` を追加（minor bump）

Closes #22

## Test plan

- `pnpm build` — 全パッケージビルド成功、`packages/react/dist/styles/chat-message.css` が生成されることを確認
- `pnpm typecheck` — 全パッケージ型チェック pass
- `pnpm test` — 全 277 テスト pass
- Example app でテーブルが罫線付きで表示されることをローカル確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)