### PR TITLE
feat(react): ConnectionStatusBadge — 接続・レート制限状態バッジの追加

### DIFF
--- a/.changeset/connection-status-badge.md
+++ b/.changeset/connection-status-badge.md
@@ -1,0 +1,5 @@
+---
+"@synapse-chat/react": minor
+---
+
+Add `ConnectionStatusBadge` component for displaying connection and rate-limit state

--- a/packages/react/src/components/ConnectionStatusBadge.tsx
+++ b/packages/react/src/components/ConnectionStatusBadge.tsx
@@ -1,0 +1,63 @@
+import type { ReactElement } from "react";
+import { cn } from "../lib/utils.js";
+import type { ConnectionStatus } from "../lib/ws-client.js";
+
+export type ConnectionStatusBadgeVariant = "default" | "compact";
+
+export interface ConnectionStatusBadgeProps {
+  status: ConnectionStatus;
+  isRateLimited?: boolean;
+  className?: string;
+  variant?: ConnectionStatusBadgeVariant;
+}
+
+export function ConnectionStatusBadge({
+  status,
+  isRateLimited = false,
+  className,
+  variant = "default",
+}: ConnectionStatusBadgeProps): ReactElement | null {
+  if (status === "connected" && !isRateLimited) {
+    return null;
+  }
+
+  const isCompact = variant === "compact";
+
+  let dotClass: string;
+  let text: string;
+  let textClass: string;
+
+  if (isRateLimited) {
+    dotClass = "bg-amber-400 animate-pulse";
+    text = "Rate limit — retrying...";
+    textClass = "text-amber-400/80";
+  } else if (status === "disconnected") {
+    dotClass = "bg-red-400";
+    text = "Disconnected";
+    textClass = "text-red-400/80";
+  } else {
+    dotClass = "bg-gray-400 animate-pulse";
+    text = "Reconnecting...";
+    textClass = "text-gray-400/80";
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2",
+        isCompact ? "px-2 py-1 text-xs" : "px-3 py-2 text-sm",
+        textClass,
+        className,
+      )}
+    >
+      <span
+        className={cn(
+          "inline-block rounded-full flex-shrink-0",
+          isCompact ? "h-1.5 w-1.5" : "h-2 w-2",
+          dotClass,
+        )}
+      />
+      <span>{text}</span>
+    </div>
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,6 +8,11 @@ export {
   type CompactionBadgeProps,
 } from "./components/CompactionBadge.js";
 export {
+  ConnectionStatusBadge,
+  type ConnectionStatusBadgeProps,
+  type ConnectionStatusBadgeVariant,
+} from "./components/ConnectionStatusBadge.js";
+export {
   ToolUseGroup,
   type ToolUseGroupProps,
 } from "./components/ToolUseGroup.js";


### PR DESCRIPTION
## Summary

`@synapse-chat/react` に `ConnectionStatusBadge` コンポーネントを追加する。接続状態（切断・再接続中）とレート制限状態をバッジとして表示する。

## Changes

- **新規** `packages/react/src/components/ConnectionStatusBadge.tsx` — コンポーネント本体
- **更新** `packages/react/src/index.ts` — `ConnectionStatusBadge` / `ConnectionStatusBadgeProps` / `ConnectionStatusBadgeVariant` エクスポート追加
- **新規** `.changeset/connection-status-badge.md` — minor changeset

## 仕様

- `status === "connected"` かつ `isRateLimited !== true` → `null`（非表示）
- `isRateLimited === true` → amber スタイルで "Rate limit — retrying..."
- `status === "disconnected"` → red スタイルで "Disconnected"
- `status === "reconnecting"` → gray スタイルで "Reconnecting..."
- `variant`: `"default"` (通常サイズ) / `"compact"` (小さいサイズ)

Closes #23

## Test plan

- `pnpm typecheck` — TypeScript 型チェック pass ✅
- `pnpm build` — ビルド成功 ✅
- `pnpm test` — 全テスト pass (229 tests) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)