### PR TITLE
feat(react): CollapsibleOutput — 長い出力テキストの折りたたみコンポーネント

### DIFF
--- a/.changeset/collapsible-output.md
+++ b/.changeset/collapsible-output.md
@@ -1,0 +1,5 @@
+---
+"@synapse-chat/react": minor
+---
+
+Add `CollapsibleOutput` component for truncating long text output with show-more / show-less toggle. Add `maxOutputLines` prop to `ToolUseGroup` and `ChatMessage` for opt-in collapsible tool result content.

--- a/packages/react/src/components/ChatMessage.tsx
+++ b/packages/react/src/components/ChatMessage.tsx
@@ -14,6 +14,7 @@ import { cn, isSafeUrl } from "../lib/utils.js";
 import { formatTime } from "../lib/format-time.js";
 import { remarkIssueLink } from "../lib/remark-issue-link.js";
 import { CompactionBadge } from "./CompactionBadge.js";
+import { CollapsibleOutput } from "./CollapsibleOutput.js";
 
 /** Convert base64 ImageAttachments to object URLs, revoking on cleanup. */
 function useImageObjectUrls(images: ImageAttachment[] | undefined): string[] {
@@ -78,6 +79,12 @@ export interface ChatMessageProps {
   renderMeta?: (message: StreamMessage) => ReactNode | null;
   /** Override react-markdown's URL sanitizer. Use this to allow custom URL schemes (e.g. `familia://`). */
   urlTransform?: (url: string) => string;
+  /**
+   * When set, `tool_result` content exceeding this many lines is wrapped in
+   * `CollapsibleOutput` with show-more / show-less toggle.
+   * When omitted, the existing pre block renders without truncation.
+   */
+  maxOutputLines?: number;
 }
 
 export const ChatMessage = memo(function ChatMessage({
@@ -87,6 +94,7 @@ export const ChatMessage = memo(function ChatMessage({
   renderSystem,
   renderMeta,
   urlTransform = defaultUrlTransform,
+  maxOutputLines,
 }: ChatMessageProps) {
   const [toolExpanded, setToolExpanded] = useState(false);
   const [resultExpanded, setResultExpanded] = useState(false);
@@ -140,24 +148,33 @@ export const ChatMessage = memo(function ChatMessage({
   if (message.type === "tool_result") {
     return (
       <div className="flex w-full justify-start">
-        <button
-          type="button"
+        <div
           className={cn(
-            "max-w-[90%] rounded border-l-2 border-emerald-500/30 px-3 py-1.5 cursor-pointer select-none text-left",
-            "hover:bg-muted/30 transition-colors",
+            "max-w-[90%] rounded border-l-2 border-emerald-500/30 px-3 py-1.5 text-left",
           )}
-          onClick={() => setResultExpanded(!resultExpanded)}
         >
-          <div className="flex items-center gap-1.5 text-xs font-mono text-emerald-400/70">
+          <button
+            type="button"
+            className="flex items-center gap-1.5 text-xs font-mono text-emerald-400/70 cursor-pointer select-none hover:text-emerald-400 transition-colors w-full text-left"
+            onClick={() => setResultExpanded(!resultExpanded)}
+          >
             <span className="text-[10px]">{resultExpanded ? "▼" : "▶"}</span>
             <span>result</span>
-          </div>
+          </button>
           {resultExpanded && message.content && (
-            <pre className="whitespace-pre-wrap break-words text-xs text-muted-foreground/80 mt-1.5 font-mono leading-relaxed max-h-60 overflow-y-auto">
-              {message.content}
-            </pre>
+            maxOutputLines !== undefined ? (
+              <CollapsibleOutput
+                content={message.content}
+                maxLines={maxOutputLines}
+                className="mt-1.5"
+              />
+            ) : (
+              <pre className="whitespace-pre-wrap break-words text-xs text-muted-foreground/80 mt-1.5 font-mono leading-relaxed max-h-60 overflow-y-auto">
+                {message.content}
+              </pre>
+            )
           )}
-        </button>
+        </div>
       </div>
     );
   }

--- a/packages/react/src/components/CollapsibleOutput.tsx
+++ b/packages/react/src/components/CollapsibleOutput.tsx
@@ -1,0 +1,44 @@
+import { useState, type ReactElement } from "react";
+import { cn } from "../lib/utils.js";
+
+export interface CollapsibleOutputProps {
+  content: string;
+  maxLines?: number;
+  label?: string;
+  className?: string;
+  defaultExpanded?: boolean;
+}
+
+export function CollapsibleOutput({
+  content,
+  maxLines = 3,
+  className,
+  defaultExpanded = false,
+}: CollapsibleOutputProps): ReactElement {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const lines = content.split("\n");
+  const needsCollapse = lines.length > maxLines;
+  const displayContent = expanded || !needsCollapse
+    ? content
+    : lines.slice(0, maxLines).join("\n");
+
+  return (
+    <div className={cn("", className)}>
+      <pre className="whitespace-pre-wrap break-words text-xs text-muted-foreground/80 font-mono leading-relaxed">
+        {displayContent}
+      </pre>
+      {needsCollapse && (
+        <button
+          type="button"
+          className="text-xs text-muted-foreground/50 hover:text-muted-foreground transition-colors mt-1 cursor-pointer"
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded(!expanded);
+          }}
+        >
+          {expanded ? "show less" : `show more (${lines.length - maxLines} more lines)`}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/react/src/components/ToolUseGroup.tsx
+++ b/packages/react/src/components/ToolUseGroup.tsx
@@ -6,13 +6,14 @@ import type { ToolUseGroupItem } from "../lib/group-tool-messages.js";
 export interface ToolUseGroupProps {
   group: ToolUseGroupItem;
   context?: ChatMessageContext;
+  maxOutputLines?: number;
 }
 
 /**
  * Collapsible wrapper for a sequence of consecutive `tool_use` / `tool_result`
  * messages produced by {@link groupToolMessages}.
  */
-export function ToolUseGroup({ group, context }: ToolUseGroupProps) {
+export function ToolUseGroup({ group, context, maxOutputLines }: ToolUseGroupProps) {
   const [expanded, setExpanded] = useState(false);
   const toolUseCount = group.messages.filter((m) => m.type === "tool_use").length;
 
@@ -42,6 +43,7 @@ export function ToolUseGroup({ group, context }: ToolUseGroupProps) {
               key={msg.timestamp ?? i}
               message={msg}
               {...(context !== undefined ? { context } : {})}
+              {...(maxOutputLines !== undefined ? { maxOutputLines } : {})}
             />
           ))}
         </div>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,10 @@ export {
   type ChatMessageProps,
 } from "./components/ChatMessage.js";
 export {
+  CollapsibleOutput,
+  type CollapsibleOutputProps,
+} from "./components/CollapsibleOutput.js";
+export {
   CompactionBadge,
   type CompactionBadgeProps,
 } from "./components/CompactionBadge.js";


### PR DESCRIPTION
## Summary

- `CollapsibleOutput` コンポーネントを新規追加（`maxLines` を超える行は show-more / show-less トグルで展開）
- `ToolUseGroup` に `maxOutputLines` prop を追加（opt-in、省略時は後方互換）
- `ChatMessage` に `maxOutputLines` prop を追加して ToolUseGroup から伝播
- `@synapse-chat/react` のエクスポートに `CollapsibleOutput` / `CollapsibleOutputProps` を追加
- nested button HTML violation を回避するため `tool_result` ブランチのレンダリング構造を改修

Closes #24

## Changes

- `packages/react/src/components/CollapsibleOutput.tsx` — 新規コンポーネント
- `packages/react/src/components/ChatMessage.tsx` — `maxOutputLines` prop 追加、`tool_result` ブランチ改修
- `packages/react/src/components/ToolUseGroup.tsx` — `maxOutputLines` prop 追加
- `packages/react/src/index.ts` — CollapsibleOutput エクスポート追加
- `.changeset/collapsible-output.md` — minor changeset

## Test plan

- `pnpm typecheck` — 全パッケージ pass ✅
- `pnpm test` — 88 tests pass ✅
- playwright による UI 動作確認は implementation-gate で実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)