### PR TITLE
feat(react): add SystemMessageBadge component

### DIFF
--- a/.changeset/system-message-badge.md
+++ b/.changeset/system-message-badge.md
@@ -1,0 +1,18 @@
+---
+"@synapse-chat/react": minor
+---
+
+Add `SystemMessageBadge` component for rendering system message subtypes as styled badges.
+
+Consumers pass a `variants` map of `subtype → { label, icon?, colorClass? }` and the component renders the matching badge, or a `fallback` node when the subtype is not found. An optional `message` prop provides access to the full `StreamMessage` for metadata.
+
+```tsx
+<SystemMessageBadge
+  subtype={message.subtype ?? ""}
+  variants={{
+    "gate-check-request": { label: "Gate Check", icon: "🔍", colorClass: "bg-indigo-100 text-indigo-800" },
+    "lookout-alert":      { label: "Alert",      icon: "🚨", colorClass: "bg-red-100 text-red-800" },
+  }}
+  message={message}
+/>
+```

--- a/packages/react/src/components/SystemMessageBadge.test.tsx
+++ b/packages/react/src/components/SystemMessageBadge.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { SystemMessageBadge } from "./SystemMessageBadge.js";
+
+afterEach(() => cleanup());
+
+const variants = {
+  "gate-check": { label: "Gate Check", icon: "🔍", colorClass: "bg-indigo-100 text-indigo-800" },
+  "alert": { label: "Alert", colorClass: "bg-red-100 text-red-800" },
+};
+
+describe("<SystemMessageBadge />", () => {
+  it("renders label and icon for a known subtype", () => {
+    render(<SystemMessageBadge subtype="gate-check" variants={variants} />);
+    expect(screen.getByText("Gate Check")).toBeInTheDocument();
+    expect(screen.getByText("🔍")).toBeInTheDocument();
+  });
+
+  it("renders label without icon when icon is omitted", () => {
+    render(<SystemMessageBadge subtype="alert" variants={variants} />);
+    expect(screen.getByText("Alert")).toBeInTheDocument();
+  });
+
+  it("renders fallback for unknown subtype", () => {
+    render(
+      <SystemMessageBadge
+        subtype="unknown"
+        variants={variants}
+        fallback={<span data-testid="fb">fallback</span>}
+      />,
+    );
+    expect(screen.getByTestId("fb")).toBeInTheDocument();
+  });
+
+  it("returns null when subtype is unknown and no fallback provided", () => {
+    const { container } = render(
+      <SystemMessageBadge subtype="unknown" variants={variants} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("applies className to the badge element", () => {
+    const { container } = render(
+      <SystemMessageBadge subtype="gate-check" variants={variants} className="extra-class" />,
+    );
+    expect(container.firstChild).toHaveClass("extra-class");
+  });
+
+  it("accepts message prop without type errors", () => {
+    render(
+      <SystemMessageBadge
+        subtype="gate-check"
+        variants={variants}
+        message={{ type: "system", subtype: "gate-check" }}
+      />,
+    );
+    expect(screen.getByText("Gate Check")).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/SystemMessageBadge.tsx
+++ b/packages/react/src/components/SystemMessageBadge.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement, ReactNode } from "react";
+import type { StreamMessage } from "@synapse-chat/core";
+import { cn } from "../lib/utils.js";
+
+export interface SystemMessageVariantConfig {
+  label: string;
+  icon?: string;
+  colorClass?: string;
+}
+
+export interface SystemMessageBadgeProps {
+  subtype: string;
+  variants: Record<string, SystemMessageVariantConfig>;
+  fallback?: ReactNode;
+  className?: string;
+  message?: StreamMessage;
+}
+
+export function SystemMessageBadge({
+  subtype,
+  variants,
+  fallback,
+  className,
+  message: _message,
+}: SystemMessageBadgeProps): ReactElement | null {
+  const config = variants[subtype];
+
+  if (!config) {
+    return (fallback ?? null) as ReactElement | null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium",
+        config.colorClass,
+        className,
+      )}
+    >
+      {config.icon && <span aria-hidden="true">{config.icon}</span>}
+      <span>{config.label}</span>
+    </div>
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -17,6 +17,11 @@ export {
   type ConnectionStatusBadgeVariant,
 } from "./components/ConnectionStatusBadge.js";
 export {
+  SystemMessageBadge,
+  type SystemMessageBadgeProps,
+  type SystemMessageVariantConfig,
+} from "./components/SystemMessageBadge.js";
+export {
   ToolUseGroup,
   type ToolUseGroupProps,
 } from "./components/ToolUseGroup.js";


### PR DESCRIPTION
## Summary

汎用システム通知バッジコンポーネント `SystemMessageBadge` を `@synapse-chat/react` に追加する。消費側が `variants` マップ（subtype → label/icon/colorClass）を渡すだけでバッジを描画でき、未知の subtype には `fallback` で対応する。

## Changes

- `packages/react/src/components/SystemMessageBadge.tsx` — 新規コンポーネント実装（`SystemMessageBadge`, `SystemMessageBadgeProps`, `SystemMessageVariantConfig`）
- `packages/react/src/components/SystemMessageBadge.test.tsx` — 6 件のユニットテスト追加
- `packages/react/src/index.ts` — 上記 3 型をエクスポート追加
- `.changeset/system-message-badge.md` — minor changeset 追加

Closes #25

## Test plan

- `pnpm typecheck` — pass（全パッケージ）
- `pnpm test` — 94 tests pass（`SystemMessageBadge.test.tsx` 6 件含む）
- `pnpm lint` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)