### PR TITLE
feat: add gemmaAdapter for Ollama/Gemma local LLM (CLIAdapter)

### DIFF
--- a/.changeset/gemma-adapter.md
+++ b/.changeset/gemma-adapter.md
@@ -1,0 +1,9 @@
+---
+"@synapse-chat/server": minor
+---
+
+Add `gemmaAdapter` for Ollama/Gemma local LLM support via `CLIAdapter` interface.
+
+`gemmaAdapter` connects to a `run_gemma4.sh` CLI wrapper that calls the Ollama
+OpenAI-compatible API and streams Claude-compatible JSON to stdout. Configure the
+binary path with `GEMMA_CLI_PATH` and model with `GEMMA_MODEL` (light/middle/heavy).

--- a/packages/server/src/adapters/gemma.test.ts
+++ b/packages/server/src/adapters/gemma.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { buildGemmaArgs, parseGemmaOutput, gemmaAdapter } from "./gemma.js";
+
+describe("buildGemmaArgs", () => {
+  let originalModel: string | undefined;
+  let originalCLIPath: string | undefined;
+
+  beforeEach(() => {
+    originalModel = process.env.GEMMA_MODEL;
+    originalCLIPath = process.env.GEMMA_CLI_PATH;
+    delete process.env.GEMMA_MODEL;
+    delete process.env.GEMMA_CLI_PATH;
+  });
+
+  afterEach(() => {
+    if (originalModel === undefined) {
+      delete process.env.GEMMA_MODEL;
+    } else {
+      process.env.GEMMA_MODEL = originalModel;
+    }
+    if (originalCLIPath === undefined) {
+      delete process.env.GEMMA_CLI_PATH;
+    } else {
+      process.env.GEMMA_CLI_PATH = originalCLIPath;
+    }
+  });
+
+  it("returns empty args when no prompt and no model env var", () => {
+    expect(buildGemmaArgs({})).toEqual([]);
+  });
+
+  it("adds -p when prompt is set", () => {
+    expect(buildGemmaArgs({ prompt: "hello" })).toEqual(["-p", "hello"]);
+  });
+
+  it("adds -m from GEMMA_MODEL env var", () => {
+    process.env.GEMMA_MODEL = "gemma4-light";
+    expect(buildGemmaArgs({})).toEqual(["-m", "gemma4-light"]);
+  });
+
+  it("adds both -m and -p when both are present", () => {
+    process.env.GEMMA_MODEL = "gemma4-heavy";
+    expect(buildGemmaArgs({ prompt: "test" })).toEqual([
+      "-m",
+      "gemma4-heavy",
+      "-p",
+      "test",
+    ]);
+  });
+
+  it("ignores non-gemma options like resumeSessionId or allowedTools", () => {
+    const args = buildGemmaArgs({
+      prompt: "hi",
+      resumeSessionId: "sess-1",
+      allowedTools: ["Read"],
+      systemPrompt: "sys",
+    });
+    expect(args).toEqual(["-p", "hi"]);
+  });
+});
+
+describe("parseGemmaOutput", () => {
+  it("returns null for empty line", () => {
+    expect(parseGemmaOutput("")).toBeNull();
+    expect(parseGemmaOutput("   ")).toBeNull();
+  });
+
+  it("returns null for non-JSON line", () => {
+    expect(parseGemmaOutput("not json")).toBeNull();
+  });
+
+  it("parses assistant message with text content block", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello there!" }],
+      },
+    });
+    const result = parseGemmaOutput(line);
+    expect(result).toMatchObject({ type: "assistant", content: "Hello there!" });
+  });
+
+  it("parses result message", () => {
+    const line = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      result: "Final answer",
+      usage: { input_tokens: 10, output_tokens: 20 },
+    });
+    const result = parseGemmaOutput(line);
+    expect(result).toMatchObject({
+      type: "result",
+      content: "Final answer",
+    });
+  });
+
+  it("returns null for result without result field", () => {
+    const line = JSON.stringify({ type: "result", subtype: "success" });
+    expect(parseGemmaOutput(line)).toBeNull();
+  });
+
+  it("returns null for unknown type", () => {
+    const line = JSON.stringify({ type: "unknown_type", data: "foo" });
+    expect(parseGemmaOutput(line)).toBeNull();
+  });
+});
+
+describe("gemmaAdapter", () => {
+  it("uses GEMMA_CLI_PATH env var when set", () => {
+    const original = process.env.GEMMA_CLI_PATH;
+    process.env.GEMMA_CLI_PATH = "/usr/local/bin/run_gemma4.sh";
+    const adapter = { ...gemmaAdapter };
+    expect(adapter.command).toBe("run_gemma4.sh");
+    if (original === undefined) {
+      delete process.env.GEMMA_CLI_PATH;
+    } else {
+      process.env.GEMMA_CLI_PATH = original;
+    }
+  });
+
+  it("has empty rate limit and retryable error patterns", () => {
+    expect(gemmaAdapter.rateLimitPatterns).toEqual([]);
+    expect(gemmaAdapter.retryableErrorPatterns).toEqual([]);
+  });
+});

--- a/packages/server/src/adapters/gemma.ts
+++ b/packages/server/src/adapters/gemma.ts
@@ -1,0 +1,33 @@
+import type { CLIAdapter, SessionOptions, StreamMessage } from "@synapse-chat/core";
+import { parseStreamMessage } from "../stream-parser.js";
+import { safeJsonParse } from "../util/json-safe.js";
+
+export function buildGemmaArgs(options: SessionOptions): string[] {
+  const args: string[] = [];
+  const model = process.env.GEMMA_MODEL;
+  if (model) {
+    args.push("-m", model);
+  }
+  if (options.prompt) {
+    args.push("-p", options.prompt);
+  }
+  return args;
+}
+
+export function parseGemmaOutput(line: string): StreamMessage | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const raw = safeJsonParse<Record<string, unknown>>(trimmed, {
+    source: "gemmaAdapter.parseOutput",
+  });
+  if (!raw) return null;
+  return parseStreamMessage(raw);
+}
+
+export const gemmaAdapter: CLIAdapter = {
+  command: process.env.GEMMA_CLI_PATH ?? "run_gemma4.sh",
+  buildArgs: buildGemmaArgs,
+  parseOutput: parseGemmaOutput,
+  rateLimitPatterns: [],
+  retryableErrorPatterns: [],
+};

--- a/packages/server/src/adapters/index.ts
+++ b/packages/server/src/adapters/index.ts
@@ -11,3 +11,9 @@ export {
   parseGeminiOutput,
   formatGeminiInput,
 } from "./gemini.js";
+
+export {
+  gemmaAdapter,
+  buildGemmaArgs,
+  parseGemmaOutput,
+} from "./gemma.js";

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -45,7 +45,7 @@ export type {
   TokenUsage,
 } from "@synapse-chat/core";
 
-// CLI adapters (Claude, Gemini). Re-exported via the "./adapters" subpath too.
+// CLI adapters (Claude, Gemini, Gemma). Re-exported via the "./adapters" subpath too.
 export {
   claudeAdapter,
   buildClaudeArgs,
@@ -55,4 +55,7 @@ export {
   buildGeminiArgs,
   parseGeminiOutput,
   formatGeminiInput,
+  gemmaAdapter,
+  buildGemmaArgs,
+  parseGemmaOutput,
 } from "./adapters/index.js";


### PR DESCRIPTION
## Summary

- Rewrites `run_gemma4.sh` to stream Claude-compatible JSON via Ollama SSE API instead of interactive `ollama run`
- Adds `gemmaAdapter` implementing `CLIAdapter` interface (same pattern as `claudeAdapter` / `geminiAdapter`)
- Exports `gemmaAdapter` from `@synapse-chat/server`

## Changes

- `~/Projects/Platform/llms/run_gemma4.sh` — Rewritten: accepts `-m <model>` and `-p <prompt>`, calls Ollama OpenAI-compatible SSE API, outputs Claude-compatible stream-json
- `packages/server/src/adapters/gemma.ts` — New `CLIAdapter` implementation with `buildGemmaArgs` / `parseGemmaOutput` / `gemmaAdapter`
- `packages/server/src/adapters/gemma.test.ts` — Unit tests (13 tests)
- `packages/server/src/adapters/index.ts` — Export `gemmaAdapter`
- `packages/server/src/index.ts` — Export `gemmaAdapter`
- `.changeset/gemma-adapter.md` — minor changeset for `@synapse-chat/server`

Closes #32

## Test plan

- `pnpm typecheck` ✅ all packages pass
- `pnpm test` ✅ 129 tests pass (13 new tests for gemmaAdapter)
- `pnpm lint` ✅ no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)