### PR TITLE
feat: Ollama streaming/non-streaming support and collapsible thinking display

### DIFF
--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -2,8 +2,11 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ChatMessage,
   SessionInput,
+  ThinkingMessage,
   ToolUseGroup,
+  groupThinkingMessages,
   groupToolMessages,
+  isThinkingGroup,
   isToolGroup,
   useWebSocket,
   type ImageAttachment,
@@ -106,7 +109,10 @@ export function App() {
     setStatusBanner("Session reset.");
   }, [send]);
 
-  const groups = useMemo(() => groupToolMessages(messages), [messages]);
+  const groups = useMemo(
+    () => groupThinkingMessages(groupToolMessages(messages)),
+    [messages],
+  );
 
   return (
     <div className="flex h-full flex-col bg-background text-foreground">
@@ -155,6 +161,9 @@ export function App() {
           {groups.map((item, i) => {
             if (isToolGroup(item)) {
               return <ToolUseGroup key={`tools-${i}`} group={item} />;
+            }
+            if (isThinkingGroup(item)) {
+              return <ThinkingMessage key={`think-${i}`} group={item} />;
             }
             return (
               <ChatMessage

--- a/packages/core/src/cli-adapter.ts
+++ b/packages/core/src/cli-adapter.ts
@@ -24,6 +24,14 @@ export interface SessionOptions {
    * Leave unset for interactive chat sessions where a human should approve.
    */
   autoApprove?: boolean;
+  /**
+   * Streaming mode toggle for adapters that wrap an HTTP-based backend such as
+   * Ollama. When `true`, the adapter emits one {@link StreamMessage} per token
+   * delta as they arrive. When `false`, the adapter buffers the entire response
+   * and emits a single message once generation completes. Adapters that don't
+   * support a non-streaming mode may ignore this flag.
+   */
+  stream?: boolean;
 }
 
 /**

--- a/packages/react/src/components/ChatMessage.test.tsx
+++ b/packages/react/src/components/ChatMessage.test.tsx
@@ -18,6 +18,20 @@ describe("<ChatMessage />", () => {
     expect(bold.tagName).toBe("STRONG");
   });
 
+  it("renders a thinking-subtyped assistant message via the collapsible block", () => {
+    render(
+      <ChatMessage
+        message={{
+          type: "assistant",
+          subtype: "thinking",
+          content: "scratchpad",
+        }}
+      />,
+    );
+    expect(screen.getByText("scratchpad")).toBeInTheDocument();
+    expect(screen.getByText(/Thinking\.\.\./)).toBeInTheDocument();
+  });
+
   it("returns null for system messages without a renderer", () => {
     const { container } = render(
       <ChatMessage message={{ type: "system", subtype: "unknown", content: "x" }} />,

--- a/packages/react/src/components/ChatMessage.tsx
+++ b/packages/react/src/components/ChatMessage.tsx
@@ -15,6 +15,7 @@ import { formatTime } from "../lib/format-time.js";
 import { remarkIssueLink } from "../lib/remark-issue-link.js";
 import { CompactionBadge } from "./CompactionBadge.js";
 import { CollapsibleOutput } from "./CollapsibleOutput.js";
+import { CollapsibleThinking } from "./CollapsibleThinking.js";
 
 /** Convert base64 ImageAttachments to object URLs, revoking on cleanup. */
 function useImageObjectUrls(images: ImageAttachment[] | undefined): string[] {
@@ -116,6 +117,18 @@ export const ChatMessage = memo(function ChatMessage({
   const isUser = message.type === "user";
   const isError = message.type === "error";
   const isSystem = message.type === "system";
+
+  if (message.type === "assistant" && message.subtype === "thinking") {
+    return (
+      <div className="flex w-full justify-start">
+        <CollapsibleThinking
+          content={message.content ?? ""}
+          isComplete={false}
+          className="max-w-[90%]"
+        />
+      </div>
+    );
+  }
 
   if (message.type === "tool_use") {
     const hasContent =

--- a/packages/react/src/components/CollapsibleThinking.test.tsx
+++ b/packages/react/src/components/CollapsibleThinking.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { CollapsibleThinking } from "./CollapsibleThinking.js";
+
+afterEach(() => cleanup());
+
+describe("<CollapsibleThinking />", () => {
+  it("renders expanded while incomplete and shows the thinking content", () => {
+    render(
+      <CollapsibleThinking content="line a\nline b" isComplete={false} />,
+    );
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(/line a/)).toBeInTheDocument();
+    expect(screen.getByText(/Thinking\.\.\./)).toBeInTheDocument();
+  });
+
+  it("auto-collapses once isComplete flips to true", () => {
+    const { rerender } = render(
+      <CollapsibleThinking content="reasoning" isComplete={false} />,
+    );
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "true");
+
+    rerender(<CollapsibleThinking content="reasoning" isComplete={true} />);
+
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
+    expect(screen.queryByText("reasoning")).not.toBeInTheDocument();
+  });
+
+  it("respects manual user toggles after auto state changes", () => {
+    const { rerender } = render(
+      <CollapsibleThinking content="reasoning" isComplete={false} />,
+    );
+
+    rerender(<CollapsibleThinking content="reasoning" isComplete={true} />);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("reasoning")).toBeInTheDocument();
+  });
+
+  it("hides the content pane while collapsed", () => {
+    render(<CollapsibleThinking content="secret" isComplete={true} />);
+    expect(screen.queryByText("secret")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("secret")).toBeInTheDocument();
+  });
+
+  it("uses a custom label when provided", () => {
+    render(
+      <CollapsibleThinking
+        content="x"
+        isComplete={true}
+        label="Reasoning"
+      />,
+    );
+    expect(screen.getByText("Reasoning")).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/CollapsibleThinking.tsx
+++ b/packages/react/src/components/CollapsibleThinking.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState, type ReactElement } from "react";
+import { cn } from "../lib/utils.js";
+
+export interface CollapsibleThinkingProps {
+  /** Aggregated thinking content emitted by the model. */
+  content: string;
+  /**
+   * Whether generation has finished. While `false`, the block is expanded so
+   * the user can watch the reasoning stream in. Once flipped to `true`, the
+   * block auto-collapses (the user can still re-expand by clicking).
+   */
+  isComplete: boolean;
+  /** Optional label shown next to the disclosure triangle. */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Disclosure block for the assistant's thinking content. Mirrors the visual
+ * weight of {@link CollapsibleOutput} but auto-collapses once generation
+ * completes so the answer body remains the focus.
+ */
+export function CollapsibleThinking({
+  content,
+  isComplete,
+  label = "Thinking",
+  className,
+}: CollapsibleThinkingProps): ReactElement {
+  const [userToggled, setUserToggled] = useState(false);
+  const [expanded, setExpanded] = useState(!isComplete);
+
+  useEffect(() => {
+    if (userToggled) return;
+    setExpanded(!isComplete);
+  }, [isComplete, userToggled]);
+
+  const displayLabel = isComplete ? label : `${label}...`;
+
+  return (
+    <div className={cn("w-full", className)}>
+      <button
+        type="button"
+        className={cn(
+          "flex items-center gap-1.5 text-xs font-mono text-muted-foreground/70",
+          "hover:text-muted-foreground transition-colors cursor-pointer select-none",
+        )}
+        onClick={(e) => {
+          e.stopPropagation();
+          setUserToggled(true);
+          setExpanded((v) => !v);
+        }}
+        aria-expanded={expanded}
+      >
+        <span className="text-[10px]">{expanded ? "▼" : "▶"}</span>
+        <span>{displayLabel}</span>
+      </button>
+      {expanded && content && (
+        <pre
+          className={cn(
+            "whitespace-pre-wrap break-words text-xs text-muted-foreground/80",
+            "font-mono leading-relaxed mt-1 border-l-2 border-muted-foreground/20 pl-2",
+          )}
+        >
+          {content}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/packages/react/src/components/ThinkingMessage.test.tsx
+++ b/packages/react/src/components/ThinkingMessage.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { ThinkingMessage } from "./ThinkingMessage.js";
+import type { ThinkingGroupItem } from "../lib/group-tool-messages.js";
+
+afterEach(() => cleanup());
+
+function group(content: string, isComplete: boolean): ThinkingGroupItem {
+  return { kind: "thinking-group", content, isComplete };
+}
+
+describe("<ThinkingMessage />", () => {
+  it("renders group content expanded while incomplete", () => {
+    render(<ThinkingMessage group={group("step 1\nstep 2", false)} />);
+    expect(screen.getByText(/step 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Thinking\.\.\./)).toBeInTheDocument();
+  });
+
+  it("renders collapsed when the group reports complete", () => {
+    render(<ThinkingMessage group={group("hidden", true)} />);
+    expect(screen.queryByText("hidden")).not.toBeInTheDocument();
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
+  });
+
+  it("honors an explicit isComplete override", () => {
+    render(
+      <ThinkingMessage group={group("shown", false)} isComplete={true} />,
+    );
+    expect(screen.queryByText("shown")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("shown")).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/ThinkingMessage.tsx
+++ b/packages/react/src/components/ThinkingMessage.tsx
@@ -1,0 +1,33 @@
+import type { ReactElement } from "react";
+import type { ThinkingGroupItem } from "../lib/group-tool-messages.js";
+import { CollapsibleThinking } from "./CollapsibleThinking.js";
+
+export interface ThinkingMessageProps {
+  group: ThinkingGroupItem;
+  /**
+   * Override the group's own `isComplete`. Useful when the app has a
+   * separate "generation finished" signal (e.g. the WebSocket emitted a
+   * `result` event the decoder dropped).
+   */
+  isComplete?: boolean;
+  className?: string;
+}
+
+/**
+ * Render a {@link ThinkingGroupItem} produced by `groupThinkingMessages` as
+ * a collapsible disclosure block. Auto-collapses once the upstream signals
+ * that thinking has concluded.
+ */
+export function ThinkingMessage({
+  group,
+  isComplete,
+  className,
+}: ThinkingMessageProps): ReactElement {
+  return (
+    <CollapsibleThinking
+      content={group.content}
+      isComplete={isComplete ?? group.isComplete}
+      {...(className !== undefined ? { className } : {})}
+    />
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,6 +8,14 @@ export {
   type CollapsibleOutputProps,
 } from "./components/CollapsibleOutput.js";
 export {
+  CollapsibleThinking,
+  type CollapsibleThinkingProps,
+} from "./components/CollapsibleThinking.js";
+export {
+  ThinkingMessage,
+  type ThinkingMessageProps,
+} from "./components/ThinkingMessage.js";
+export {
   CompactionBadge,
   type CompactionBadgeProps,
 } from "./components/CompactionBadge.js";
@@ -53,9 +61,12 @@ export {
 export {
   groupToolMessages,
   isToolGroup,
+  isThinkingGroup,
   type DisplayItem,
   type ToolUseGroupItem,
+  type ThinkingGroupItem,
 } from "./lib/group-tool-messages.js";
+export { groupThinkingMessages } from "./lib/group-thinking-messages.js";
 export {
   createMessageFilter,
   type CreateMessageFilterOptions,

--- a/packages/react/src/lib/group-thinking-messages.test.ts
+++ b/packages/react/src/lib/group-thinking-messages.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import type { StreamMessage } from "@synapse-chat/core";
+import { groupThinkingMessages } from "./group-thinking-messages.js";
+import {
+  isThinkingGroup,
+  isToolGroup,
+  type DisplayItem,
+  type ThinkingGroupItem,
+  type ToolUseGroupItem,
+} from "./group-tool-messages.js";
+
+function thinkingMsg(content: string, extra?: Partial<StreamMessage>): StreamMessage {
+  return {
+    type: "assistant",
+    subtype: "thinking",
+    content,
+    timestamp: Date.now(),
+    ...extra,
+  };
+}
+
+function assistantMsg(content: string, extra?: Partial<StreamMessage>): StreamMessage {
+  return { type: "assistant", content, timestamp: Date.now(), ...extra };
+}
+
+describe("groupThinkingMessages", () => {
+  it("returns empty array for empty input", () => {
+    expect(groupThinkingMessages([])).toEqual([]);
+  });
+
+  it("passes non-thinking items through untouched", () => {
+    const input: DisplayItem[] = [assistantMsg("hi"), assistantMsg("there")];
+    expect(groupThinkingMessages(input)).toEqual(input);
+  });
+
+  it("folds consecutive thinking chunks into a single group", () => {
+    const input: DisplayItem[] = [
+      thinkingMsg("Let me "),
+      thinkingMsg("think "),
+      thinkingMsg("about this."),
+      assistantMsg("Done!"),
+    ];
+    const result = groupThinkingMessages(input);
+    expect(result).toHaveLength(2);
+    expect(isThinkingGroup(result[0]!)).toBe(true);
+    const group = result[0] as ThinkingGroupItem;
+    expect(group.content).toBe("Let me think about this.");
+    expect(group.isComplete).toBe(true);
+    expect((result[1] as StreamMessage).type).toBe("assistant");
+  });
+
+  it("marks the trailing thinking group as incomplete when nothing follows", () => {
+    const input: DisplayItem[] = [
+      thinkingMsg("still "),
+      thinkingMsg("reasoning"),
+    ];
+    const result = groupThinkingMessages(input);
+    expect(result).toHaveLength(1);
+    const group = result[0] as ThinkingGroupItem;
+    expect(group.isComplete).toBe(false);
+    expect(group.content).toBe("still reasoning");
+  });
+
+  it("splits groups around interleaving content", () => {
+    const input: DisplayItem[] = [
+      thinkingMsg("first"),
+      assistantMsg("hello"),
+      thinkingMsg("second"),
+      assistantMsg("world"),
+    ];
+    const result = groupThinkingMessages(input);
+    expect(result).toHaveLength(4);
+    expect(isThinkingGroup(result[0]!)).toBe(true);
+    expect((result[0] as ThinkingGroupItem).isComplete).toBe(true);
+    expect(isThinkingGroup(result[2]!)).toBe(true);
+    expect((result[2] as ThinkingGroupItem).isComplete).toBe(true);
+  });
+
+  it("preserves the timestamp of the first thinking chunk in the group", () => {
+    const ts = 1700000000000;
+    const input: DisplayItem[] = [
+      thinkingMsg("a", { timestamp: ts }),
+      thinkingMsg("b", { timestamp: ts + 100 }),
+      assistantMsg("end"),
+    ];
+    const result = groupThinkingMessages(input);
+    expect((result[0] as ThinkingGroupItem).timestamp).toBe(ts);
+  });
+
+  it("treats tool groups as non-thinking and completes any preceding group", () => {
+    const toolGroup: ToolUseGroupItem = { kind: "tool-group", messages: [] };
+    const input: DisplayItem[] = [thinkingMsg("planning"), toolGroup];
+    const result = groupThinkingMessages(input);
+    expect(result).toHaveLength(2);
+    expect(isThinkingGroup(result[0]!)).toBe(true);
+    expect((result[0] as ThinkingGroupItem).isComplete).toBe(true);
+    expect(isToolGroup(result[1]!)).toBe(true);
+  });
+
+  it("passes already-folded thinking groups through untouched", () => {
+    const existing: ThinkingGroupItem = {
+      kind: "thinking-group",
+      content: "pre-folded",
+      isComplete: true,
+    };
+    const input: DisplayItem[] = [existing, assistantMsg("ok")];
+    const result = groupThinkingMessages(input);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(existing);
+  });
+});
+
+describe("isThinkingGroup", () => {
+  it("returns true for ThinkingGroupItem", () => {
+    const item: ThinkingGroupItem = {
+      kind: "thinking-group",
+      content: "",
+      isComplete: false,
+    };
+    expect(isThinkingGroup(item)).toBe(true);
+  });
+
+  it("returns false for StreamMessage", () => {
+    expect(isThinkingGroup(assistantMsg("x") as DisplayItem)).toBe(false);
+  });
+
+  it("returns false for ToolUseGroupItem", () => {
+    const item: ToolUseGroupItem = { kind: "tool-group", messages: [] };
+    expect(isThinkingGroup(item)).toBe(false);
+  });
+});

--- a/packages/react/src/lib/group-thinking-messages.ts
+++ b/packages/react/src/lib/group-thinking-messages.ts
@@ -1,0 +1,55 @@
+import {
+  isThinkingGroup,
+  isToolGroup,
+  type DisplayItem,
+  type ThinkingGroupItem,
+} from "./group-tool-messages.js";
+
+/**
+ * Fold consecutive `assistant + subtype:"thinking"` messages into a single
+ * {@link ThinkingGroupItem}. Other items (`tool-group`, plain
+ * StreamMessages, already-folded thinking groups) pass through untouched.
+ *
+ * A group is marked `isComplete: true` when at least one non-thinking item
+ * follows it in the input. The final group is left `isComplete: false` so
+ * the UI can keep the disclosure expanded while tokens are still streaming
+ * in. Callers that have an authoritative "generation done" signal (e.g. a
+ * `result` message that the decoder dropped) can force-flip the final
+ * group's `isComplete` themselves.
+ */
+export function groupThinkingMessages(items: DisplayItem[]): DisplayItem[] {
+  const result: DisplayItem[] = [];
+  let buffer: string[] = [];
+  let bufferTimestamp: number | undefined;
+
+  const flush = (isComplete: boolean) => {
+    if (buffer.length === 0) return;
+    const group: ThinkingGroupItem = {
+      kind: "thinking-group",
+      content: buffer.join(""),
+      isComplete,
+      ...(bufferTimestamp !== undefined ? { timestamp: bufferTimestamp } : {}),
+    };
+    result.push(group);
+    buffer = [];
+    bufferTimestamp = undefined;
+  };
+
+  for (const item of items) {
+    if (
+      !isToolGroup(item) &&
+      !isThinkingGroup(item) &&
+      item.type === "assistant" &&
+      item.subtype === "thinking"
+    ) {
+      if (buffer.length === 0) bufferTimestamp = item.timestamp;
+      buffer.push(item.content ?? "");
+      continue;
+    }
+    flush(true);
+    result.push(item);
+  }
+
+  flush(false);
+  return result;
+}

--- a/packages/react/src/lib/group-tool-messages.ts
+++ b/packages/react/src/lib/group-tool-messages.ts
@@ -6,12 +6,29 @@ export interface ToolUseGroupItem {
   timestamp?: number;
 }
 
+export interface ThinkingGroupItem {
+  kind: "thinking-group";
+  /** Aggregated thinking content of all consecutive thinking chunks. */
+  content: string;
+  /**
+   * `true` once a non-thinking message follows the group in the stream.
+   * Consumers should auto-collapse the disclosure block in this state.
+   */
+  isComplete: boolean;
+  timestamp?: number;
+}
+
 export type DisplayItem =
   | (StreamMessage & { repeatCount?: number })
-  | ToolUseGroupItem;
+  | ToolUseGroupItem
+  | ThinkingGroupItem;
 
 export function isToolGroup(item: DisplayItem): item is ToolUseGroupItem {
   return "kind" in item && item.kind === "tool-group";
+}
+
+export function isThinkingGroup(item: DisplayItem): item is ThinkingGroupItem {
+  return "kind" in item && item.kind === "thinking-group";
 }
 
 /**

--- a/packages/server/bin/ollama-runner.mjs
+++ b/packages/server/bin/ollama-runner.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { parseRunnerArgs, runOllama } from "../dist/adapters/ollama-runner.js";
+
+const args = parseRunnerArgs(process.argv.slice(2));
+try {
+  await runOllama(args);
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,9 +25,13 @@
       "default": "./dist/supervisor/index.js"
     }
   },
+  "bin": {
+    "synapse-ollama-runner": "./bin/ollama-runner.mjs"
+  },
   "files": [
     "dist",
     "src",
+    "bin",
     "!src/**/*.test.ts",
     "!src/**/test-fixtures/**"
   ],

--- a/packages/server/src/adapters/gemma.test.ts
+++ b/packages/server/src/adapters/gemma.test.ts
@@ -57,6 +57,26 @@ describe("buildGemmaArgs", () => {
     });
     expect(args).toEqual(["-p", "hi"]);
   });
+
+  it("adds --stream when stream: true", () => {
+    expect(buildGemmaArgs({ prompt: "hi", stream: true })).toEqual([
+      "-p",
+      "hi",
+      "--stream",
+    ]);
+  });
+
+  it("adds --no-stream when stream: false", () => {
+    expect(buildGemmaArgs({ prompt: "hi", stream: false })).toEqual([
+      "-p",
+      "hi",
+      "--no-stream",
+    ]);
+  });
+
+  it("omits stream flag when option is undefined", () => {
+    expect(buildGemmaArgs({ prompt: "hi" })).toEqual(["-p", "hi"]);
+  });
 });
 
 describe("parseGemmaOutput", () => {
@@ -103,6 +123,42 @@ describe("parseGemmaOutput", () => {
   it("returns null for unknown type", () => {
     const line = JSON.stringify({ type: "unknown_type", data: "foo" });
     expect(parseGemmaOutput(line)).toBeNull();
+  });
+
+  it("parses Ollama-style streaming chunk with message.content string", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { role: "assistant", content: "Hi there" },
+    });
+    expect(parseGemmaOutput(line)).toMatchObject({
+      type: "assistant",
+      content: "Hi there",
+    });
+  });
+
+  it("parses thinking chunk emitted by the Ollama runner", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      subtype: "thinking",
+      content: "Let me reason about this",
+    });
+    expect(parseGemmaOutput(line)).toMatchObject({
+      type: "assistant",
+      subtype: "thinking",
+      content: "Let me reason about this",
+    });
+  });
+
+  it("parses raw Ollama chunk where thinking is a sibling field", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      thinking: "Considering options",
+    });
+    expect(parseGemmaOutput(line)).toMatchObject({
+      type: "assistant",
+      subtype: "thinking",
+      content: "Considering options",
+    });
   });
 });
 

--- a/packages/server/src/adapters/gemma.ts
+++ b/packages/server/src/adapters/gemma.ts
@@ -11,6 +11,11 @@ export function buildGemmaArgs(options: SessionOptions): string[] {
   if (options.prompt) {
     args.push("-p", options.prompt);
   }
+  if (options.stream === true) {
+    args.push("--stream");
+  } else if (options.stream === false) {
+    args.push("--no-stream");
+  }
   return args;
 }
 

--- a/packages/server/src/adapters/index.ts
+++ b/packages/server/src/adapters/index.ts
@@ -17,3 +17,10 @@ export {
   buildGemmaArgs,
   parseGemmaOutput,
 } from "./gemma.js";
+
+export {
+  runOllama,
+  parseRunnerArgs,
+  type OllamaRunnerOptions,
+  type ParsedRunnerArgs,
+} from "./ollama-runner.js";

--- a/packages/server/src/adapters/ollama-runner.test.ts
+++ b/packages/server/src/adapters/ollama-runner.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+import { parseRunnerArgs, runOllama } from "./ollama-runner.js";
+
+function makeStreamingResponse(lines: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(line + "\n"));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "application/x-ndjson" },
+  });
+}
+
+describe("parseRunnerArgs", () => {
+  it("parses -m and -p plus default stream=true", () => {
+    expect(parseRunnerArgs(["-m", "gemma3", "-p", "hello"])).toEqual({
+      model: "gemma3",
+      prompt: "hello",
+      stream: true,
+    });
+  });
+
+  it("recognises --no-stream", () => {
+    expect(
+      parseRunnerArgs(["-m", "gemma3", "-p", "hi", "--no-stream"]),
+    ).toMatchObject({ stream: false });
+  });
+
+  it("accepts --host override", () => {
+    expect(
+      parseRunnerArgs([
+        "-m",
+        "gemma3",
+        "-p",
+        "hi",
+        "--host",
+        "http://example.test",
+      ]),
+    ).toMatchObject({ host: "http://example.test" });
+  });
+
+  it("throws when -m is missing", () => {
+    expect(() => parseRunnerArgs(["-p", "hi"])).toThrow(/-m/);
+  });
+
+  it("throws when -p is missing", () => {
+    expect(() => parseRunnerArgs(["-m", "gemma3"])).toThrow(/-p/);
+  });
+});
+
+describe("runOllama (streaming)", () => {
+  it("forwards thinking and content chunks as stream-json lines then a result", async () => {
+    const lines: string[] = [];
+    const writeLine = (line: string) => lines.push(line);
+
+    const fetchImpl = (async () =>
+      makeStreamingResponse([
+        JSON.stringify({ message: { role: "assistant", thinking: "Hmm " }, done: false }),
+        JSON.stringify({ message: { role: "assistant", thinking: "let me think." }, done: false }),
+        JSON.stringify({ message: { role: "assistant", content: "Hello" }, done: false }),
+        JSON.stringify({ message: { role: "assistant", content: " world" }, done: false }),
+        JSON.stringify({
+          message: { role: "assistant", content: "" },
+          done: true,
+          prompt_eval_count: 5,
+          eval_count: 10,
+        }),
+      ])) as unknown as typeof fetch;
+
+    const result = await runOllama({
+      model: "gemma3",
+      prompt: "hi",
+      stream: true,
+      fetchImpl,
+      writeLine,
+    });
+
+    expect(result.content).toBe("Hello world");
+    expect(result.thinking).toBe("Hmm let me think.");
+
+    const parsed = lines.map((l) => JSON.parse(l));
+    expect(parsed[0]).toMatchObject({ type: "assistant", subtype: "thinking", content: "Hmm " });
+    expect(parsed[1]).toMatchObject({ type: "assistant", subtype: "thinking", content: "let me think." });
+    expect(parsed[2]).toMatchObject({
+      type: "assistant",
+      message: { role: "assistant", content: "Hello" },
+    });
+    expect(parsed[3]).toMatchObject({
+      type: "assistant",
+      message: { role: "assistant", content: " world" },
+    });
+    expect(parsed[parsed.length - 1]).toMatchObject({
+      type: "result",
+      result: "Hello world",
+      usage: { input_tokens: 5, output_tokens: 10 },
+    });
+  });
+
+  it("passes stream: true in the request body", async () => {
+    let observed: { stream?: boolean } | undefined;
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      observed = JSON.parse(init?.body as string);
+      return makeStreamingResponse([
+        JSON.stringify({ message: { role: "assistant", content: "ok" }, done: true }),
+      ]);
+    }) as unknown as typeof fetch;
+
+    await runOllama({
+      model: "gemma3",
+      prompt: "hi",
+      stream: true,
+      fetchImpl,
+      writeLine: () => {},
+    });
+
+    expect(observed?.stream).toBe(true);
+  });
+});
+
+describe("runOllama (non-streaming)", () => {
+  it("emits a single assistant chunk then a result", async () => {
+    const lines: string[] = [];
+    const writeLine = (line: string) => lines.push(line);
+
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({
+          message: { role: "assistant", content: "Hello world" },
+          done: true,
+          prompt_eval_count: 3,
+          eval_count: 7,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof fetch;
+
+    const result = await runOllama({
+      model: "gemma3",
+      prompt: "hi",
+      stream: false,
+      fetchImpl,
+      writeLine,
+    });
+
+    expect(result.content).toBe("Hello world");
+
+    const parsed = lines.map((l) => JSON.parse(l));
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]).toMatchObject({
+      type: "assistant",
+      message: { role: "assistant", content: "Hello world" },
+    });
+    expect(parsed[1]).toMatchObject({
+      type: "result",
+      result: "Hello world",
+      usage: { input_tokens: 3, output_tokens: 7 },
+    });
+  });
+
+  it("passes stream: false in the request body", async () => {
+    let observed: { stream?: boolean } | undefined;
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      observed = JSON.parse(init?.body as string);
+      return new Response(
+        JSON.stringify({ message: { content: "ok" }, done: true }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    await runOllama({
+      model: "gemma3",
+      prompt: "hi",
+      stream: false,
+      fetchImpl,
+      writeLine: () => {},
+    });
+
+    expect(observed?.stream).toBe(false);
+  });
+
+  it("emits both thinking and content from a single response", async () => {
+    const lines: string[] = [];
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({
+          message: { role: "assistant", thinking: "deliberating", content: "done" },
+          done: true,
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch;
+
+    await runOllama({
+      model: "gemma3",
+      prompt: "hi",
+      stream: false,
+      fetchImpl,
+      writeLine: (line) => lines.push(line),
+    });
+
+    const parsed = lines.map((l) => JSON.parse(l));
+    expect(parsed[0]).toMatchObject({
+      type: "assistant",
+      subtype: "thinking",
+      content: "deliberating",
+    });
+    expect(parsed[1]).toMatchObject({
+      type: "assistant",
+      message: { content: "done" },
+    });
+  });
+});
+
+describe("runOllama (errors)", () => {
+  it("throws when the response is not OK", async () => {
+    const fetchImpl = (async () =>
+      new Response("bad model", { status: 404 })) as unknown as typeof fetch;
+
+    await expect(
+      runOllama({
+        model: "missing",
+        prompt: "hi",
+        stream: true,
+        fetchImpl,
+        writeLine: () => {},
+      }),
+    ).rejects.toThrow(/Ollama request failed/);
+  });
+});

--- a/packages/server/src/adapters/ollama-runner.ts
+++ b/packages/server/src/adapters/ollama-runner.ts
@@ -1,0 +1,211 @@
+/**
+ * In-process implementation of an Ollama-backed CLI runner.
+ *
+ * The runner POSTs a chat request to an Ollama HTTP server, then projects the
+ * response onto the stream-json format that {@link parseGemmaOutput} (and
+ * therefore {@link parseStreamMessage}) understands. It supports both
+ * streaming (NDJSON tokens forwarded as they arrive) and non-streaming
+ * (single buffered response emitted once at the end) modes.
+ */
+
+export interface OllamaRunnerOptions {
+  /** Ollama model name (`-m`). Required. */
+  model: string;
+  /** Prompt sent as a single user message (`-p`). Required. */
+  prompt: string;
+  /** When `true`, request streaming NDJSON; when `false`, request a single response. */
+  stream: boolean;
+  /** Base URL of the Ollama HTTP server. Defaults to `http://localhost:11434`. */
+  host?: string;
+  /** Override fetch implementation (used by tests). */
+  fetchImpl?: typeof fetch;
+  /** Write a stream-json line to stdout. Defaults to `console.log`. */
+  writeLine?: (line: string) => void;
+}
+
+interface OllamaChatChunk {
+  model?: string;
+  message?: {
+    role?: string;
+    content?: string;
+    thinking?: string;
+  };
+  done?: boolean;
+  total_duration?: number;
+  prompt_eval_count?: number;
+  eval_count?: number;
+}
+
+const DEFAULT_HOST = "http://localhost:11434";
+
+/**
+ * Run a single Ollama chat completion and emit stream-json lines.
+ *
+ * Returns the accumulated assistant content (for callers that want to inspect
+ * the result without re-parsing stdout).
+ */
+export async function runOllama(
+  options: OllamaRunnerOptions,
+): Promise<{ content: string; thinking: string }> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const writeLine = options.writeLine ?? ((line: string) => console.log(line));
+  const host = options.host ?? process.env.OLLAMA_HOST ?? DEFAULT_HOST;
+  const url = new URL("/api/chat", host).toString();
+
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: options.model,
+      messages: [{ role: "user", content: options.prompt }],
+      stream: options.stream,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `Ollama request failed: ${response.status} ${response.statusText} ${body}`.trim(),
+    );
+  }
+
+  let accumulatedContent = "";
+  let accumulatedThinking = "";
+  let promptTokens = 0;
+  let completionTokens = 0;
+
+  const processChunk = (chunk: OllamaChatChunk) => {
+    const thinking = chunk.message?.thinking;
+    if (typeof thinking === "string" && thinking.length > 0) {
+      accumulatedThinking += thinking;
+      writeLine(
+        JSON.stringify({
+          type: "assistant",
+          subtype: "thinking",
+          content: thinking,
+        }),
+      );
+    }
+    const content = chunk.message?.content;
+    if (typeof content === "string" && content.length > 0) {
+      accumulatedContent += content;
+      writeLine(
+        JSON.stringify({
+          type: "assistant",
+          message: { role: "assistant", content },
+        }),
+      );
+    }
+    if (chunk.done) {
+      promptTokens = chunk.prompt_eval_count ?? promptTokens;
+      completionTokens = chunk.eval_count ?? completionTokens;
+    }
+  };
+
+  if (options.stream) {
+    if (!response.body) {
+      throw new Error("Ollama streaming response has no body");
+    }
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (true) {
+      const { value, done } = await reader.read();
+      if (value) {
+        buffer += decoder.decode(value, { stream: true });
+        let newlineIdx: number;
+        while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, newlineIdx).trim();
+          buffer = buffer.slice(newlineIdx + 1);
+          if (!line) continue;
+          const parsed = parseChunk(line);
+          if (parsed) processChunk(parsed);
+        }
+      }
+      if (done) break;
+    }
+    const tail = buffer.trim();
+    if (tail) {
+      const parsed = parseChunk(tail);
+      if (parsed) processChunk(parsed);
+    }
+  } else {
+    const body = await response.text();
+    const parsed = parseChunk(body.trim());
+    if (parsed) processChunk(parsed);
+  }
+
+  writeLine(
+    JSON.stringify({
+      type: "result",
+      subtype: "success",
+      result: accumulatedContent,
+      usage: {
+        input_tokens: promptTokens,
+        output_tokens: completionTokens,
+      },
+    }),
+  );
+
+  return { content: accumulatedContent, thinking: accumulatedThinking };
+}
+
+function parseChunk(line: string): OllamaChatChunk | null {
+  try {
+    return JSON.parse(line) as OllamaChatChunk;
+  } catch {
+    return null;
+  }
+}
+
+export interface ParsedRunnerArgs {
+  model: string;
+  prompt: string;
+  stream: boolean;
+  host?: string;
+}
+
+/**
+ * Parse argv passed to the CLI entry point. Mirrors `buildGemmaArgs`:
+ * `-m <model> -p <prompt> [--stream|--no-stream]` plus an optional
+ * `--host <url>` override.
+ */
+export function parseRunnerArgs(argv: readonly string[]): ParsedRunnerArgs {
+  let model: string | undefined;
+  let prompt: string | undefined;
+  let stream = true;
+  let host: string | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "-m":
+      case "--model":
+        model = argv[++i];
+        break;
+      case "-p":
+      case "--prompt":
+        prompt = argv[++i];
+        break;
+      case "--stream":
+      case "-s":
+        stream = true;
+        break;
+      case "--no-stream":
+        stream = false;
+        break;
+      case "--host":
+        host = argv[++i];
+        break;
+      default:
+        // Ignore unknown flags so future SessionOptions additions don't break
+        // the runner. buildGemmaArgs only emits the flags above today.
+        break;
+    }
+  }
+
+  if (!model) throw new Error("ollama-runner: -m <model> is required");
+  if (!prompt) throw new Error("ollama-runner: -p <prompt> is required");
+
+  return { model, prompt, stream, ...(host ? { host } : {}) };
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -58,4 +58,8 @@ export {
   gemmaAdapter,
   buildGemmaArgs,
   parseGemmaOutput,
+  runOllama,
+  parseRunnerArgs,
+  type OllamaRunnerOptions,
+  type ParsedRunnerArgs,
 } from "./adapters/index.js";

--- a/packages/server/src/stream-parser.test.ts
+++ b/packages/server/src/stream-parser.test.ts
@@ -271,6 +271,60 @@ describe("parseStreamMessage", () => {
         timestamp: expect.any(Number),
       });
     });
+
+    it("returns subtype: thinking when an Ollama runner emits a thinking chunk", () => {
+      const result = parseStreamMessage({
+        type: "assistant",
+        subtype: "thinking",
+        content: "Considering options",
+      });
+      expect(result).toEqual({
+        type: "assistant",
+        subtype: "thinking",
+        content: "Considering options",
+        timestamp: expect.any(Number),
+      });
+    });
+
+    it("maps a raw Ollama chunk with sibling `thinking` field to subtype: thinking", () => {
+      const result = parseStreamMessage({
+        type: "assistant",
+        thinking: "weighing tradeoffs",
+      });
+      expect(result).toEqual({
+        type: "assistant",
+        subtype: "thinking",
+        content: "weighing tradeoffs",
+        timestamp: expect.any(Number),
+      });
+    });
+
+    it("maps thinking-typed content block to subtype: thinking", () => {
+      const result = parseStreamMessage({
+        type: "assistant",
+        message: {
+          content: [{ type: "thinking", text: "step 1" }],
+        },
+      });
+      expect(result).toEqual({
+        type: "assistant",
+        subtype: "thinking",
+        content: "step 1",
+        timestamp: expect.any(Number),
+      });
+    });
+
+    it("treats Ollama-style message.content string as a plain assistant message", () => {
+      const result = parseStreamMessage({
+        type: "assistant",
+        message: { role: "assistant", content: "Hello world" },
+      });
+      expect(result).toEqual({
+        type: "assistant",
+        content: "Hello world",
+        timestamp: expect.any(Number),
+      });
+    });
   });
 
   // === system ===

--- a/packages/server/src/stream-parser.ts
+++ b/packages/server/src/stream-parser.ts
@@ -113,8 +113,50 @@ function parseStreamMessageInner(
 ): StreamMessage | null {
   switch (type) {
     case "assistant": {
-      const msg = raw.message as { content?: ContentBlock[] } | undefined;
-      const blocks = msg?.content ?? [];
+      const subtype = raw.subtype as string | undefined;
+      if (subtype === "thinking") {
+        const text =
+          (raw.content as string | undefined) ??
+          (raw.text as string | undefined) ??
+          (raw.thinking as string | undefined);
+        if (!text) return null;
+        return {
+          type: "assistant",
+          subtype: "thinking",
+          content: text,
+        };
+      }
+
+      // Ollama-style chunks that emit `thinking` and `content` siblings without
+      // a Claude-style content-block array. Map them to subtype:"thinking" /
+      // plain assistant messages so downstream UIs can group them.
+      if (typeof raw.thinking === "string" && raw.thinking.length > 0) {
+        return {
+          type: "assistant",
+          subtype: "thinking",
+          content: raw.thinking as string,
+        };
+      }
+
+      const msg = raw.message as { content?: ContentBlock[] | string } | undefined;
+      if (typeof msg?.content === "string" && msg.content.length > 0) {
+        return {
+          type: "assistant",
+          content: msg.content,
+        };
+      }
+      const blocks = (Array.isArray(msg?.content) ? msg.content : []) as ContentBlock[];
+
+      const thinkingTexts = blocks
+        .filter((b) => b.type === "thinking" && b.text)
+        .map((b) => b.text as string);
+      if (thinkingTexts.length > 0) {
+        return {
+          type: "assistant",
+          subtype: "thinking",
+          content: thinkingTexts.join("\n"),
+        };
+      }
 
       const texts = blocks
         .filter((b) => b.type === "text" && b.text)


### PR DESCRIPTION
## Summary

- Ollama アダプタにストリーミング/非ストリーミング両モードを実装。`SessionOptions.stream: boolean` で切り替え可能。
- 内蔵 Node ランナー (`packages/server/bin/ollama-runner.mjs`) を追加。Ollama HTTP API (`/api/chat`) を直接叩き、`thinking` チャンクを `subtype: "thinking"` の StreamMessage として stream-json に変換。
- React 側に `CollapsibleThinking` / `ThinkingMessage` コンポーネントと `groupThinkingMessages` ヘルパーを追加。生成中は thinking を逐次表示、完了で自動折りたたみ、クリックで再展開できる。

## Changes

### Core (`@synapse-chat/core`)
- `SessionOptions` に `stream?: boolean` を追加

### Server (`@synapse-chat/server`)
- `src/adapters/ollama-runner.ts` — 内蔵 Ollama HTTP ランナー本体（streaming + non-streaming + thinking）
- `bin/ollama-runner.mjs` — `synapse-ollama-runner` bin エントリポイント
- `src/adapters/gemma.ts` — `buildGemmaArgs` が `options.stream` を `--stream` / `--no-stream` として forward
- `src/stream-parser.ts` — Ollama 形式の thinking フィールド/コンテンツブロック/string content を正規化

### React (`@synapse-chat/react`)
- `CollapsibleThinking` — 進行中の thinking 表示 + 自動折りたたみ
- `ThinkingMessage` — `ThinkingGroupItem` を受け取る薄いラッパー
- `groupThinkingMessages` — 連続する thinking メッセージを 1 ブロックに集約
- `ChatMessage` — 単体の `subtype: "thinking"` を `CollapsibleThinking` で描画
- 例アプリ `apps/example/src/App.tsx` を更新（grouping パイプライン拡張）

Closes #36

## Test plan

- [x] `pnpm build` (5 ワークスペース + example app)
- [x] `pnpm typecheck`
- [x] `pnpm test` — 150 server / 114 react / 4 core / 61 mcp tests pass
- [x] `pnpm lint`
- [ ] 手動 E2E: 実 Ollama を起動して streaming/non-streaming 両モードで thinking → 折りたたみを確認（Playwright reviewer に委譲）

🤖 Generated with [Claude Code](https://claude.com/claude-code)