### PR TITLE
refactor(core): promote StreamMessage to a typed discriminated union

### DIFF
--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -170,7 +170,7 @@ export function App() {
                 key={`msg-${i}`}
                 message={item}
                 renderSystem={(m) =>
-                  m.subtype === "status" ? (
+                  m.type === "system" && m.subtype === "status" ? (
                     <div className="text-xs italic text-muted-foreground">
                       {m.content}
                     </div>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,9 +1,21 @@
 export type {
   ImageAttachment,
   StreamMessage,
+  StreamMessageBase,
   StreamMessageType,
+  AssistantMessage,
+  ThinkingMessage,
+  ToolUseMessage,
+  ToolResultMessage,
+  ResultMessage,
+  UserMessage,
+  SystemMessage,
+  ErrorMessage,
+  HistoryMessage,
+  QuestionMessage,
   TokenUsage,
 } from "./types.js";
+export { isAssistantBody, isThinkingMessage, assertNever } from "./types.js";
 export type { CLIAdapter, SessionOptions } from "./cli-adapter.js";
 export type {
   ProcessManagerLike,

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { assertNever, isAssistantBody, isThinkingMessage } from "./index.js";
 import type {
   CLIAdapter,
   ImageAttachment,
@@ -14,6 +15,38 @@ describe("@synapse-chat/core type surface", () => {
       timestamp: 1_700_000_000_000,
     };
     expect(msg.type).toBe("assistant");
+  });
+
+  it("discriminates a plain assistant body delta from a thinking chunk", () => {
+    const body: StreamMessage = { type: "assistant", content: "hi" };
+    const thinking: StreamMessage = {
+      type: "assistant",
+      subtype: "thinking",
+      content: "reasoning",
+    };
+
+    expect(isAssistantBody(body)).toBe(true);
+    expect(isThinkingMessage(body)).toBe(false);
+    expect(isAssistantBody(thinking)).toBe(false);
+    expect(isThinkingMessage(thinking)).toBe(true);
+  });
+
+  it("narrows result usage through the discriminant", () => {
+    const msg: StreamMessage = {
+      type: "result",
+      content: "done",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    };
+    // Exhaustive branch: only `result` carries `usage`.
+    if (msg.type === "result") {
+      expect(msg.usage?.inputTokens).toBe(10);
+    }
+  });
+
+  it("assertNever throws when reached at runtime", () => {
+    expect(() => assertNever("unexpected" as never)).toThrow(
+      /Unhandled StreamMessage variant/,
+    );
   });
 
   it("ImageAttachment narrows media type", () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,9 +1,18 @@
 /**
- * Stream message types emitted by a CLI adapter.
+ * Stream message types emitted by a CLI adapter, modeled as a typed
+ * discriminated union (ADR-0018 §3).
  *
  * Derived from Claude Code's stream-json output and generalized so that other
- * CLIs (e.g. Gemini) can emit the same shape. Apps layer their own semantics
- * on top via `subtype` (free-form string) and `meta` (free-form record).
+ * CLIs (e.g. Gemini, Ollama) can emit the same shape. Framework-level
+ * streaming semantics — a plain assistant body delta, a `thinking` chunk,
+ * `tool_use` / `tool_result`, and a terminal `result` carrying token usage —
+ * are distinct variants so that an emit/consume convention drift surfaces as a
+ * compile error rather than a silent runtime bug.
+ *
+ * App-specific semantics layer onto the open {@link SystemMessage} variant via
+ * a free-form `subtype` plus a typed `meta` record; the framework does not
+ * interpret either. This keeps the extension surface type-safe without forcing
+ * generic synapse-chat to enumerate app concepts.
  */
 
 export type StreamMessageType =
@@ -37,28 +46,132 @@ export interface TokenUsage {
   cacheWrite?: number;
 }
 
-/**
- * A single normalized event from a CLI stream.
- *
- * Adapters are responsible for mapping CLI-specific stdout lines to this shape
- * via {@link CLIAdapter.parseOutput}. Additional fields are allowed (index
- * signature) so apps can smuggle adapter-specific payloads without widening
- * the core type.
- */
-export interface StreamMessage {
-  type: StreamMessageType;
-  content?: string;
-  tool?: string;
-  toolInput?: Record<string, unknown>;
-  toolUseId?: string;
-  /** App-specific subcategory. Framework does not interpret this. */
-  subtype?: string;
-  /** App-specific metadata. Framework does not interpret this. */
-  meta?: Record<string, unknown>;
+/** Fields shared by every {@link StreamMessage} variant. */
+export interface StreamMessageBase {
   timestamp?: number;
+  /** App-specific metadata. The framework does not interpret this. */
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * A plain assistant body delta. Per-token streaming (e.g. Ollama) emits one of
+ * these per chunk; consumers concatenate consecutive deltas into one bubble.
+ * The absent `subtype` is what distinguishes it from {@link ThinkingMessage}.
+ */
+export interface AssistantMessage extends StreamMessageBase {
+  type: "assistant";
+  subtype?: undefined;
+  content: string;
   images?: ImageAttachment[];
   imageCount?: number;
-  /** Token usage; populated by adapters on `type: "result"` messages when available. */
+}
+
+/** An assistant reasoning ("thinking") chunk, grouped separately from body. */
+export interface ThinkingMessage extends StreamMessageBase {
+  type: "assistant";
+  subtype: "thinking";
+  content: string;
+}
+
+/** A tool invocation. */
+export interface ToolUseMessage extends StreamMessageBase {
+  type: "tool_use";
+  tool?: string;
+  content?: string;
+  toolInput?: Record<string, unknown>;
+  toolUseId?: string;
+}
+
+/** The result of a tool invocation. */
+export interface ToolResultMessage extends StreamMessageBase {
+  type: "tool_result";
+  content?: string;
+  toolUseId?: string;
+}
+
+/** Terminal message for a generation; carries token usage when available. */
+export interface ResultMessage extends StreamMessageBase {
+  type: "result";
+  content?: string;
+  /** Populated by adapters when the CLI reports session-end token counts. */
   usage?: TokenUsage;
-  [key: string]: unknown;
+}
+
+/** An echoed user message. */
+export interface UserMessage extends StreamMessageBase {
+  type: "user";
+  content?: string;
+  images?: ImageAttachment[];
+  imageCount?: number;
+}
+
+/**
+ * App-extensible control / system message. The framework does not interpret
+ * `subtype`; apps layer their own semantics (e.g. `compact-status`,
+ * `dispatch-log`, `task-notification`) on top. This single open variant is the
+ * type-safe extension point that replaces the former index signature.
+ */
+export interface SystemMessage extends StreamMessageBase {
+  type: "system";
+  /** App-specific subcategory. The framework does not interpret this. */
+  subtype?: string;
+  content?: string;
+}
+
+/** A transport- or CLI-level error surfaced into the stream. */
+export interface ErrorMessage extends StreamMessageBase {
+  type: "error";
+  content?: string;
+}
+
+/** A replayed history entry. */
+export interface HistoryMessage extends StreamMessageBase {
+  type: "history";
+  content?: string;
+}
+
+/** A question awaiting user input. */
+export interface QuestionMessage extends StreamMessageBase {
+  type: "question";
+  content?: string;
+}
+
+/**
+ * A single normalized event from a CLI stream, as a discriminated union over
+ * {@link StreamMessageType}. Adapters map CLI-specific stdout lines to one of
+ * these variants via {@link CLIAdapter.parseOutput}.
+ */
+export type StreamMessage =
+  | AssistantMessage
+  | ThinkingMessage
+  | ToolUseMessage
+  | ToolResultMessage
+  | ResultMessage
+  | UserMessage
+  | SystemMessage
+  | ErrorMessage
+  | HistoryMessage
+  | QuestionMessage;
+
+/** True for a plain assistant body delta (mergeable per-token chunk). */
+export function isAssistantBody(
+  message: StreamMessage,
+): message is AssistantMessage {
+  return message.type === "assistant" && message.subtype === undefined;
+}
+
+/** True for an assistant `thinking` chunk. */
+export function isThinkingMessage(
+  message: StreamMessage,
+): message is ThinkingMessage {
+  return message.type === "assistant" && message.subtype === "thinking";
+}
+
+/**
+ * Exhaustiveness guard. Reaching this in a `switch`/`if` chain at compile time
+ * means a {@link StreamMessage} variant is unhandled; at runtime it throws so
+ * the convention drift is loud rather than silent.
+ */
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled StreamMessage variant: ${JSON.stringify(value)}`);
 }

--- a/packages/react/src/components/ChatMessage.tsx
+++ b/packages/react/src/components/ChatMessage.tsx
@@ -99,7 +99,9 @@ export const ChatMessage = memo(function ChatMessage({
 }: ChatMessageProps) {
   const [toolExpanded, setToolExpanded] = useState(false);
   const [resultExpanded, setResultExpanded] = useState(false);
-  const imageUrls = useImageObjectUrls(message.images);
+  const imageUrls = useImageObjectUrls(
+    "images" in message ? message.images : undefined,
+  );
 
   const remarkPlugins: PluggableList = useMemo(
     () => [
@@ -229,11 +231,6 @@ export const ChatMessage = memo(function ChatMessage({
               : "bg-card text-card-foreground",
         )}
       >
-        {message.tool && (
-          <span className="text-xs font-mono text-muted-foreground block mb-1">
-            [{message.tool}]
-          </span>
-        )}
         {isUser && imageUrls.length > 0 && (
           <div className="flex gap-1.5 flex-wrap mb-1.5">
             {imageUrls.map((url, i) => (

--- a/packages/react/src/lib/group-thinking-messages.ts
+++ b/packages/react/src/lib/group-thinking-messages.ts
@@ -1,3 +1,4 @@
+import { isThinkingMessage } from "@synapse-chat/core";
 import {
   isThinkingGroup,
   isToolGroup,
@@ -39,11 +40,10 @@ export function groupThinkingMessages(items: DisplayItem[]): DisplayItem[] {
     if (
       !isToolGroup(item) &&
       !isThinkingGroup(item) &&
-      item.type === "assistant" &&
-      item.subtype === "thinking"
+      isThinkingMessage(item)
     ) {
       if (buffer.length === 0) bufferTimestamp = item.timestamp;
-      buffer.push(item.content ?? "");
+      buffer.push(item.content);
       continue;
     }
     flush(true);


### PR DESCRIPTION
## Summary

Promotes the intentionally-loose `StreamMessage` (`[key: string]: unknown` + free-form `subtype` + untyped `meta`) to a **typed discriminated union** over the stream `type` (ADR-0018 §3). Framework-level streaming semantics become distinct variants — `AssistantMessage` (plain body delta), `ThinkingMessage`, `ToolUseMessage` / `ToolResultMessage`, and `ResultMessage` (token usage) — so an emit/consume convention drift surfaces as a **compile error** instead of a silent runtime bug (#347 / #365 / #454 / #477 class).

App-specific semantics stay type-safe via the open `SystemMessage` variant (free-form `subtype` + typed `meta`); generic synapse-chat does not enumerate app concepts (ADR-0018 §6). The wire `type` values are unchanged, so persisted history / storage round-trips are unaffected.

- add `isAssistantBody` / `isThinkingMessage` type guards + `assertNever` exhaustiveness helper (exported from `@synapse-chat/core` and re-exported from `@synapse-chat/react`)
- `groupThinkingMessages` branches on `isThinkingMessage` instead of the magic-string `subtype` check
- `ChatMessage`: guard image access by variant; drop a dead tool-label block (`tool_use` already returns early)

## Cross-repo

This is the synapse-chat half of agents-familia#528 (ADR-0018 子D). The adopting PR in agents-familia migrates `streamMerge` / `agent-manager` / `SessionChat` onto these guards. **This PR must merge first** — agents-familia CI builds against synapse-chat `main`.

## Test plan

- [x] `pnpm build` (all packages + example app)
- [x] `pnpm -F @synapse-chat/core test` (7 — adds union guard + exhaustiveness tests)
- [x] `pnpm -F @synapse-chat/react test` (114 — incl. `group-thinking-messages` isComplete / #454)
- [x] `pnpm -F @synapse-chat/server test` (150 — incl. `stream-parser` 57)
- [x] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)