### PR TITLE
refactor(core): unify attachments into a single typed Attachment model

### DIFF
--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -9,6 +9,7 @@ import {
   isThinkingGroup,
   isToolGroup,
   useWebSocket,
+  type Attachment,
   type ImageAttachment,
   type StreamMessage,
   type WSClientOptions,
@@ -81,9 +82,14 @@ export function App() {
   }, [client]);
 
   const handleSend = useCallback(
-    (text: string, images?: ImageAttachment[]) => {
+    (text: string, attachments?: Attachment[]) => {
       const trimmed = text.trim();
-      if (!trimmed && (!images || images.length === 0)) return;
+      if (!trimmed && (!attachments || attachments.length === 0)) return;
+
+      // This demo only renders/forwards image attachments.
+      const images = attachments?.filter(
+        (a): a is ImageAttachment => a.kind === "image",
+      );
 
       // Optimistic local echo: render the user's own message immediately.
       // The server may also echo a `user` StreamMessage; either is fine —

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,6 @@
 export type {
+  Attachment,
+  AttachmentImageMediaType,
   ImageAttachment,
   StreamMessage,
   StreamMessageBase,

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { assertNever, isAssistantBody, isThinkingMessage } from "./index.js";
 import type {
+  Attachment,
   CLIAdapter,
   ImageAttachment,
   SessionOptions,
@@ -50,8 +51,23 @@ describe("@synapse-chat/core type surface", () => {
   });
 
   it("ImageAttachment narrows media type", () => {
-    const img: ImageAttachment = { base64: "AAAA", mediaType: "image/png" };
+    const img: ImageAttachment = {
+      kind: "image",
+      base64: "AAAA",
+      mediaType: "image/png",
+    };
     expect(img.mediaType).toBe("image/png");
+  });
+
+  it("Attachment discriminates image vs text on `kind`", () => {
+    const attachments: Attachment[] = [
+      { kind: "image", base64: "AAAA", mediaType: "image/png", name: "a.png" },
+      { kind: "text", content: "hello", mimeType: "text/plain", name: "n.txt" },
+    ];
+    const summary = attachments.map((a) =>
+      a.kind === "image" ? a.mediaType : a.mimeType,
+    );
+    expect(summary).toEqual(["image/png", "text/plain"]);
   });
 
   it("CLIAdapter can be satisfied by a minimal implementation", () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,11 +26,35 @@ export type StreamMessageType =
   | "history"
   | "question";
 
-/** Base64-encoded image attached to a user message. */
-export interface ImageAttachment {
-  base64: string;
-  mediaType: "image/png" | "image/jpeg" | "image/gif" | "image/webp";
-}
+/** Media types accepted for an inline image attachment. */
+export type AttachmentImageMediaType =
+  | "image/png"
+  | "image/jpeg"
+  | "image/gif"
+  | "image/webp";
+
+/**
+ * Unified attachment model (ADR-0018 §4). The single source of truth for a file
+ * the user attaches to a message: the same type flows UI → WS → server → CLI, so
+ * there is no per-layer redefinition to drift out of sync. Image variants carry
+ * the raw base64 bytes; text variants carry the decoded UTF-8 content.
+ */
+export type Attachment =
+  | {
+      kind: "image";
+      base64: string;
+      mediaType: AttachmentImageMediaType;
+      name?: string;
+    }
+  | { kind: "text"; content: string; mimeType: string; name?: string };
+
+/**
+ * @deprecated Use {@link Attachment} (the `kind: "image"` variant). Retained as
+ * the image-only narrow for the render paths that only ever deal with images
+ * (e.g. {@link AssistantMessage.images}). Derived from {@link Attachment}, so it
+ * is not a separate definition.
+ */
+export type ImageAttachment = Extract<Attachment, { kind: "image" }>;
 
 /**
  * Normalized token usage attached to a `result` {@link StreamMessage}.

--- a/packages/react/src/components/SessionInput.tsx
+++ b/packages/react/src/components/SessionInput.tsx
@@ -9,7 +9,7 @@ import {
   type ChangeEvent,
 } from "react";
 import { Send, X, ImageIcon } from "lucide-react";
-import type { ImageAttachment } from "@synapse-chat/core";
+import type { Attachment, AttachmentImageMediaType } from "@synapse-chat/core";
 import { cn } from "../lib/utils.js";
 
 const ACCEPTED_TYPES = new Set<string>([
@@ -27,16 +27,46 @@ const ACCEPTED_TYPES = new Set<string>([
   "text/x-yaml",
 ]);
 
-type ImageMediaType = ImageAttachment["mediaType"];
-
 const DEFAULT_MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 const DEFAULT_MAX_IMAGES = 10;
 const MAX_ROWS = 6;
 const LINE_HEIGHT = 20;
 const PADDING_Y = 8;
 
-interface PreviewAttachment extends ImageAttachment {
+/**
+ * A file the user has staged but not yet sent. Holds the raw base64 bytes and
+ * the original MIME (which may be an image, text, or document type), plus an
+ * object URL for the thumbnail. Converted to a typed {@link Attachment} on send.
+ */
+interface PreviewAttachment {
+  base64: string;
+  mediaType: string;
+  name: string;
   objectUrl: string;
+}
+
+/** Decode a base64 payload as UTF-8 text (used for non-image attachments). */
+function decodeBase64Utf8(base64: string): string {
+  const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+  return new TextDecoder("utf-8").decode(bytes);
+}
+
+/** Convert a staged preview into the typed wire {@link Attachment}. */
+function toAttachment(preview: PreviewAttachment): Attachment {
+  if (preview.mediaType.startsWith("image/")) {
+    return {
+      kind: "image",
+      base64: preview.base64,
+      mediaType: preview.mediaType as AttachmentImageMediaType,
+      name: preview.name,
+    };
+  }
+  return {
+    kind: "text",
+    content: decodeBase64Utf8(preview.base64),
+    mimeType: preview.mediaType,
+    name: preview.name,
+  };
 }
 
 function fileToAttachment(file: File): Promise<PreviewAttachment> {
@@ -48,7 +78,8 @@ function fileToAttachment(file: File): Promise<PreviewAttachment> {
       const objectUrl = URL.createObjectURL(file);
       resolve({
         base64,
-        mediaType: file.type as ImageMediaType,
+        mediaType: file.type,
+        name: file.name,
         objectUrl,
       });
     };
@@ -64,10 +95,11 @@ export interface SessionInputProps {
   onChange: (value: string) => void;
   /**
    * Called when the user hits Enter or the send button. Receives the trimmed
-   * text and optional image attachments. The component clears its image
-   * buffer on send; the caller is responsible for clearing `value`.
+   * text and optional typed attachments (image or text). The component clears
+   * its attachment buffer on send; the caller is responsible for clearing
+   * `value`.
    */
-  onSend: (message: string, images?: ImageAttachment[]) => void;
+  onSend: (message: string, attachments?: Attachment[]) => void;
   disabled?: boolean;
   placeholder?: string;
   /** Maximum number of images the user can attach in a single send. */
@@ -150,10 +182,8 @@ export function SessionInput({
   const handleSend = useCallback(() => {
     const trimmed = value.trim();
     if (!trimmed && images.length === 0) return;
-    const toSend: ImageAttachment[] | undefined =
-      images.length > 0
-        ? images.map(({ base64, mediaType }) => ({ base64, mediaType }))
-        : undefined;
+    const toSend: Attachment[] | undefined =
+      images.length > 0 ? images.map(toAttachment) : undefined;
     onSend(trimmed, toSend);
     for (const img of images) URL.revokeObjectURL(img.objectUrl);
     setImages([]);

--- a/packages/react/src/hooks/useChat.test.tsx
+++ b/packages/react/src/hooks/useChat.test.tsx
@@ -295,7 +295,7 @@ describe("useChat — optimistic send (online)", () => {
   it("includes images on the optimistic message and the wire payload", () => {
     const { result } = renderHook(() => useChat({ wsOptions, decode }));
     const images = [
-      { base64: "abc", mediaType: "image/png" as const },
+      { kind: "image" as const, base64: "abc", mediaType: "image/png" as const },
     ];
 
     act(() => {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -78,6 +78,8 @@ export { cn, isSafeUrl } from "./lib/utils.js";
 
 // Re-export core types that chat consumers will inevitably need.
 export type {
+  Attachment,
+  AttachmentImageMediaType,
   StreamMessage,
   StreamMessageType,
   ImageAttachment,


### PR DESCRIPTION
## Summary

Cross-repo counterpart of agents-familia **#529** (ADR-0018 §4 / §6, 子E).

- Replace the image-only `ImageAttachment` interface with a discriminated `Attachment` (`image | text`) owned by `@synapse-chat/core` — the single source of truth that flows UI → WS → server → CLI with no per-layer redefinition.
- `ImageAttachment` is kept as a **deprecated narrow** (`Extract<Attachment, { kind: "image" }>`) so the image-only render paths (`StreamMessage.images`, `ChatMessage`, process-manager) keep compiling without being a separate definition.
- `SessionInput` now emits the typed `Attachment[]` (splitting image vs text on the file MIME) instead of casting arbitrary file types to the narrow image media-type — removing the type-lie behind the #248 / #252 attachment-drop class.
- The example app narrows to image attachments for its image-only path.

## Test plan

- [x] `pnpm -r typecheck` (incl. `apps/example`)
- [x] `pnpm -r test` — core 8 / react 114 / server 150 / mcp 61, all green
- [ ] Merge together with agents-familia #529 (the familia PR imports this `Attachment`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)