### PR TITLE
fix: system:thinking_tokens が stream-parser の filter を通過してチャットログを大量に埋める

### DIFF
--- a/.changeset/drop-thinking-tokens.md
+++ b/.changeset/drop-thinking-tokens.md
@@ -1,0 +1,5 @@
+---
+"@synapse-chat/server": patch
+---
+
+Drop `system:thinking_tokens` progress events in the stream parser. Claude CLI emits these extended-thinking progress notifications roughly every second, and they were previously passing the `system` message filter — flooding chat logs, DB storage, and frontend broadcasts. The token total remains available in the `result` message's `usage` block, so cost accounting is unaffected.

--- a/packages/server/src/stream-parser.test.ts
+++ b/packages/server/src/stream-parser.test.ts
@@ -362,6 +362,16 @@ describe("parseStreamMessage", () => {
       expect(result).toBeNull();
     });
 
+    it("returns null for thinking_tokens subtype", () => {
+      const result = parseStreamMessage({
+        type: "system",
+        subtype: "thinking_tokens",
+        estimated_tokens: 50,
+        estimated_tokens_delta: 50,
+      });
+      expect(result).toBeNull();
+    });
+
     it("returns compact-status for compacting status", () => {
       const result = parseStreamMessage({
         type: "system",

--- a/packages/server/src/stream-parser.ts
+++ b/packages/server/src/stream-parser.ts
@@ -203,13 +203,18 @@ function parseStreamMessageInner(
 
     case "system": {
       const subtype = raw.subtype as string | undefined;
-      // Drop init/hook/task-progress notifications — they are internal CLI
-      // bookkeeping that clutters downstream chat panels.
+      // Drop init/hook/task-progress/thinking-token notifications — they are
+      // internal CLI bookkeeping that clutters downstream chat panels.
+      // `thinking_tokens` is an extended-thinking progress event Claude CLI
+      // emits every ~1s; the token total is also carried by the `result`
+      // message's `usage` block, so dropping the progress events does not
+      // affect cost accounting.
       if (
         subtype === "init" ||
         subtype?.startsWith("hook") ||
         subtype === "task_started" ||
-        subtype === "task_progress"
+        subtype === "task_progress" ||
+        subtype === "thinking_tokens"
       ) {
         return null;
       }


### PR DESCRIPTION
## Summary

Claude Code CLI (extended thinking モデル) が秒間隔で emit する `system:thinking_tokens` 進捗イベントが、`packages/server/src/stream-parser.ts` の `system` message filter (blocklist) を通過し、Engine broadcast / ship-log.jsonl / Commander 履歴 / UI chat panel をすべて汚染していた（観測では全行の 18〜45% を占有）。

filter に `thinking_tokens` を追加して drop する即時 hotfix。

## Changes

- `packages/server/src/stream-parser.ts`: `system` subtype filter に `subtype === "thinking_tokens"` を追加し、drop 理由コメントを更新
- `packages/server/src/stream-parser.test.ts`: `returns null for thinking_tokens subtype` テストケースを追加
- `.changeset/drop-thinking-tokens.md`: `@synapse-chat/server` patch changeset

## Notes

- `result` message の `usage` ブロックに thinking tokens 合計は別途含まれる（ADR-0020 の cost 計算に使用）ため、progress event を drop してもコスト計測に影響なし
- allowlist 化（Issue の追加提案）は破壊的変更のため本 PR では対象外。Issue 本文の「2 段構え」方針に従いまず hotfix を適用
- vibe-admiral 側の変更は不要（filter は synapse-chat 側で完結）

Closes #40

## Test plan

- `pnpm --filter @synapse-chat/server test` → 151 passed (stream-parser.test.ts 58 tests 含む)
- `pnpm --filter @synapse-chat/server typecheck` → pass
- `pnpm lint` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)