### PR TITLE
feat(claude): トークン単位のストリーミング出力に対応する（--include-partial-messages）

### DIFF
--- a/.changeset/claude-partial-streaming.md
+++ b/.changeset/claude-partial-streaming.md
@@ -1,0 +1,19 @@
+---
+"@synapse-chat/server": minor
+"@synapse-chat/core": patch
+---
+
+feat(claude): token-level streaming via `--include-partial-messages`
+
+`createClaudeAdapter({ stream: true })` makes the Claude adapter emit one
+message per token delta instead of one per finished block, matching what the
+Ollama adapter already did and what `AssistantMessage` was always documented to
+carry.
+
+The CLI emits finished `assistant` messages *in addition to* the deltas, so the
+streaming parser drops the finished `text` / `thinking` blocks and keeps only
+`tool_use` from them — tool input arrives as `input_json_delta` fragments that
+are more fragile to reassemble than to read once, whole. Each mode ignores the
+other's events, so neither can double a sentence.
+
+`claudeAdapter` (the existing const) is unchanged.

--- a/packages/core/src/cli-adapter.ts
+++ b/packages/core/src/cli-adapter.ts
@@ -24,12 +24,18 @@ export interface SessionOptions {
    * Leave unset for interactive chat sessions where a human should approve.
    */
   autoApprove?: boolean;
-  /**
-   * Streaming mode toggle for adapters that wrap an HTTP-based backend such as
-   * Ollama. When `true`, the adapter emits one {@link StreamMessage} per token
-   * delta as they arrive. When `false`, the adapter buffers the entire response
-   * and emits a single message once generation completes. Adapters that don't
-   * support a non-streaming mode may ignore this flag.
+   /**
+   * Token-level streaming toggle. When `true`, the adapter emits one
+   * {@link StreamMessage} per token delta as it arrives; consumers concatenate
+   * consecutive plain-assistant deltas into a single growing bubble. When
+   * `false`, the whole response is buffered and emitted once.
+   *
+   * Honoured by HTTP-backed adapters (Ollama) and, since #42, by the Claude CLI
+   * adapter, where it adds `--include-partial-messages`. **The adapter must be
+   * built for the same mode** (`createClaudeAdapter({ stream: true })`) so the
+   * parser knows to read deltas instead of finished blocks.
+   *
+   * Adapters with no non-streaming mode may ignore this flag.
    */
   stream?: boolean;
 }

--- a/packages/server/src/adapters/claude.ts
+++ b/packages/server/src/adapters/claude.ts
@@ -1,5 +1,8 @@
 import type { CLIAdapter, SessionOptions, StreamMessage } from "@synapse-chat/core";
-import { parseStreamMessage } from "../stream-parser.js";
+import {
+  parseStreamMessage,
+  type ParseStreamMessageOptions,
+} from "../stream-parser.js";
 import { safeJsonParse } from "../util/json-safe.js";
 
 const CLAUDE_RATE_LIMIT_PATTERNS: RegExp[] = [
@@ -46,18 +49,26 @@ export function buildClaudeArgs(options: SessionOptions): string[] {
   if (options.autoApprove) {
     args.push("--dangerously-skip-permissions");
   }
+  // Token-level streaming. Only meaningful alongside the `stream-json` output
+  // format already set above; the CLI rejects it otherwise.
+  if (options.stream) {
+    args.push("--include-partial-messages");
+  }
 
   return args;
 }
 
-export function parseClaudeOutput(line: string): StreamMessage | null {
+export function parseClaudeOutput(
+  line: string,
+  options: ParseStreamMessageOptions = {},
+): StreamMessage | null {
   const trimmed = line.trim();
   if (!trimmed) return null;
   const raw = safeJsonParse<Record<string, unknown>>(trimmed, {
     source: "claudeAdapter.parseOutput",
   });
   if (!raw) return null;
-  return parseStreamMessage(raw);
+  return parseStreamMessage(raw, options);
 }
 
 export function formatClaudeInput(message: string): string {
@@ -67,11 +78,40 @@ export function formatClaudeInput(message: string): string {
   });
 }
 
-export const claudeAdapter: CLIAdapter = {
-  command: process.env.CLAUDE_CLI_PATH ?? "claude",
-  buildArgs: buildClaudeArgs,
-  parseOutput: parseClaudeOutput,
-  formatInput: formatClaudeInput,
-  rateLimitPatterns: CLAUDE_RATE_LIMIT_PATTERNS,
-  retryableErrorPatterns: CLAUDE_RETRYABLE_ERROR_PATTERNS,
-};
+export interface ClaudeAdapterOptions {
+  /**
+   * Parse `--include-partial-messages` output as token deltas.
+   *
+   * Must match the `stream` flag handed to {@link buildClaudeArgs} for the same
+   * session: the flag decides what the CLI *emits*, this decides how the lines
+   * are *read*. Setting one without the other either drops the deltas or
+   * renders every sentence twice.
+   */
+  stream?: boolean;
+}
+
+/**
+ * Build a Claude adapter bound to a parsing mode.
+ *
+ * A factory rather than a mutable singleton because one adapter can serve many
+ * concurrent sessions; the mode has to be captured per instance, not stashed in
+ * module state where a second session would inherit it.
+ */
+export function createClaudeAdapter(
+  options: ClaudeAdapterOptions = {},
+): CLIAdapter {
+  const parseOptions: ParseStreamMessageOptions = {
+    partialMessages: options.stream === true,
+  };
+  return {
+    command: process.env.CLAUDE_CLI_PATH ?? "claude",
+    buildArgs: buildClaudeArgs,
+    parseOutput: (line) => parseClaudeOutput(line, parseOptions),
+    formatInput: formatClaudeInput,
+    rateLimitPatterns: CLAUDE_RATE_LIMIT_PATTERNS,
+    retryableErrorPatterns: CLAUDE_RETRYABLE_ERROR_PATTERNS,
+  };
+}
+
+/** Default instance — block-at-a-time parsing, unchanged from before #42. */
+export const claudeAdapter: CLIAdapter = createClaudeAdapter();

--- a/packages/server/src/adapters/index.ts
+++ b/packages/server/src/adapters/index.ts
@@ -1,8 +1,10 @@
 export {
   claudeAdapter,
+  createClaudeAdapter,
   buildClaudeArgs,
   parseClaudeOutput,
   formatClaudeInput,
+  type ClaudeAdapterOptions,
 } from "./claude.js";
 
 export {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -48,6 +48,8 @@ export type {
 // CLI adapters (Claude, Gemini, Gemma). Re-exported via the "./adapters" subpath too.
 export {
   claudeAdapter,
+  createClaudeAdapter,
+  type ClaudeAdapterOptions,
   buildClaudeArgs,
   parseClaudeOutput,
   formatClaudeInput,

--- a/packages/server/src/partial-streaming.test.ts
+++ b/packages/server/src/partial-streaming.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import { parseStreamMessage } from "./stream-parser.js";
+import { buildClaudeArgs, createClaudeAdapter } from "./adapters/index.js";
+
+/**
+ * Fixtures are verbatim lines captured from `claude 2.1.212` run with
+ * `--output-format stream-json --include-partial-messages --verbose` (#42).
+ * Hand-written approximations would not have caught that the finished
+ * `assistant` message arrives *in addition to* the deltas.
+ */
+const textDelta = {
+  type: "stream_event",
+  event: {
+    type: "content_block_delta",
+    index: 1,
+    delta: { type: "text_delta", text: "申し訳ありませんが、" },
+  },
+  session_id: "e39e396f",
+  parent_tool_use_id: null,
+};
+
+const thinkingDelta = {
+  type: "stream_event",
+  event: {
+    type: "content_block_delta",
+    index: 0,
+    delta: { type: "thinking_delta", thinking: "The user has" },
+  },
+  session_id: "e39e396f",
+  parent_tool_use_id: null,
+};
+
+const signatureDelta = {
+  type: "stream_event",
+  event: {
+    type: "content_block_delta",
+    index: 0,
+    delta: { type: "signature_delta", signature: "EpgGCqgBCBAYAipA" },
+  },
+};
+
+const lifecycle = [
+  { type: "stream_event", event: { type: "message_start", message: { id: "msg_1" } } },
+  { type: "stream_event", event: { type: "content_block_start", index: 1, content_block: { type: "text", text: "" } } },
+  { type: "stream_event", event: { type: "content_block_stop", index: 1 } },
+  { type: "stream_event", event: { type: "message_delta", delta: { stop_reason: "end_turn" } } },
+  { type: "stream_event", event: { type: "message_stop" } },
+];
+
+/** The finished message the CLI emits *as well as* the deltas above. */
+const finishedText = {
+  type: "assistant",
+  message: { role: "assistant", content: [{ type: "text", text: "申し訳ありませんが、メッセージが短すぎます。" }] },
+};
+const finishedThinking = {
+  type: "assistant",
+  message: { role: "assistant", content: [{ type: "thinking", text: "The user has written…" }] },
+};
+const finishedToolUse = {
+  type: "assistant",
+  message: {
+    role: "assistant",
+    content: [{ type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "ls" } }],
+  },
+};
+
+describe("stream_event deltas (partial mode)", () => {
+  const partial = { partialMessages: true };
+  it("turns text_delta into a plain assistant delta", () => {
+    expect(parseStreamMessage(textDelta, partial)).toMatchObject({
+      type: "assistant",
+      content: "申し訳ありませんが、",
+    });
+    expect(parseStreamMessage(textDelta, partial)?.subtype).toBeUndefined();
+  });
+
+  it("turns thinking_delta into a thinking delta", () => {
+    expect(parseStreamMessage(thinkingDelta, partial)).toMatchObject({
+      type: "assistant",
+      subtype: "thinking",
+      content: "The user has",
+    });
+  });
+
+  it("drops signature_delta — it is a cryptographic blob, not prose", () => {
+    expect(parseStreamMessage(signatureDelta, partial)).toBeNull();
+  });
+
+  it("drops every lifecycle event", () => {
+    for (const raw of lifecycle) expect(parseStreamMessage(raw, partial)).toBeNull();
+  });
+
+  it("drops empty deltas rather than emitting blank bubbles", () => {
+    const empty = { type: "stream_event", event: { type: "content_block_delta", delta: { type: "text_delta", text: "" } } };
+    expect(parseStreamMessage(empty, partial)).toBeNull();
+  });
+});
+
+describe("no double delivery in partial mode", () => {
+  const partial = { partialMessages: true };
+
+  it("suppresses the finished text — the deltas already carried it", () => {
+    expect(parseStreamMessage(finishedText, partial)).toBeNull();
+  });
+
+  it("suppresses the finished thinking", () => {
+    expect(parseStreamMessage(finishedThinking, partial)).toBeNull();
+  });
+
+  it("still emits tool_use once, since its input never arrives as usable deltas", () => {
+    expect(parseStreamMessage(finishedToolUse, partial)).toMatchObject({
+      type: "tool_use",
+      tool: "Bash",
+      toolUseId: "toolu_1",
+    });
+  });
+});
+
+describe("default mode is byte-for-byte unchanged", () => {
+  it("ignores stream_event entirely — reading both would double every sentence", () => {
+    expect(parseStreamMessage(textDelta)).toBeNull();
+    expect(parseStreamMessage(thinkingDelta)).toBeNull();
+  });
+
+  it("still emits finished text", () => {
+    expect(parseStreamMessage(finishedText)).toMatchObject({
+      type: "assistant",
+      content: "申し訳ありませんが、メッセージが短すぎます。",
+    });
+  });
+
+  it("still emits finished thinking", () => {
+    expect(parseStreamMessage(finishedThinking)).toMatchObject({
+      type: "assistant",
+      subtype: "thinking",
+    });
+  });
+
+  it("still emits tool_use", () => {
+    expect(parseStreamMessage(finishedToolUse)).toMatchObject({ type: "tool_use", tool: "Bash" });
+  });
+});
+
+describe("argv", () => {
+  it("adds --include-partial-messages only when stream is on", () => {
+    expect(buildClaudeArgs({ prompt: "hi", stream: true })).toContain("--include-partial-messages");
+    expect(buildClaudeArgs({ prompt: "hi" })).not.toContain("--include-partial-messages");
+    expect(buildClaudeArgs({ prompt: "hi", stream: false })).not.toContain("--include-partial-messages");
+  });
+
+  it("keeps stream-json, which the partial flag requires", () => {
+    const args = buildClaudeArgs({ prompt: "hi", stream: true });
+    expect(args[args.indexOf("--output-format") + 1]).toBe("stream-json");
+  });
+});
+
+describe("createClaudeAdapter binds the parsing mode per instance", () => {
+  it("a streaming instance reads deltas and drops finished prose", () => {
+    const a = createClaudeAdapter({ stream: true });
+    expect(a.parseOutput(JSON.stringify(textDelta))).toMatchObject({ content: "申し訳ありませんが、" });
+    expect(a.parseOutput(JSON.stringify(finishedText))).toBeNull();
+  });
+
+  it("a default instance ignores deltas' twin and keeps finished prose", () => {
+    const a = createClaudeAdapter();
+    expect(a.parseOutput(JSON.stringify(finishedText))).toMatchObject({ type: "assistant" });
+  });
+
+  it("two instances do not share mode — one session must not infect another", () => {
+    const streaming = createClaudeAdapter({ stream: true });
+    const plain = createClaudeAdapter();
+    expect(streaming.parseOutput(JSON.stringify(finishedText))).toBeNull();
+    expect(plain.parseOutput(JSON.stringify(finishedText))).not.toBeNull();
+  });
+});

--- a/packages/server/src/stream-parser.ts
+++ b/packages/server/src/stream-parser.ts
@@ -95,11 +95,30 @@ export function toTokenUsage(usage: ResultUsage): TokenUsage {
  *
  * Returns null for messages that should be silently dropped (e.g. hooks, init).
  */
+export interface ParseStreamMessageOptions {
+  /**
+   * Partial-message mode (Claude's `--include-partial-messages`).
+   *
+   * When the CLI streams token deltas it *also* emits the finished `assistant`
+   * message for the same content, so forwarding both would render every
+   * sentence twice. With this flag the finished message's `text` / `thinking`
+   * blocks are dropped — the deltas already carried them — while `tool_use`
+   * blocks still come from the finished message, because tool input arrives as
+   * `input_json_delta` fragments that are far more fragile to reassemble than
+   * to read once, whole.
+   *
+   * Deliberately stateless: a single adapter instance may be shared across
+   * sessions, so this must not be inferred by remembering message ids.
+   */
+  partialMessages?: boolean;
+}
+
 export function parseStreamMessage(
   raw: Record<string, unknown>,
+  options: ParseStreamMessageOptions = {},
 ): StreamMessage | null {
   const type = raw.type as string | undefined;
-  const parsed = parseStreamMessageInner(raw, type);
+  const parsed = parseStreamMessageInner(raw, type, options);
   if (parsed) {
     parsed.timestamp =
       typeof raw.timestamp === "number" ? raw.timestamp : Date.now();
@@ -107,11 +126,53 @@ export function parseStreamMessage(
   return parsed;
 }
 
+/**
+ * One `stream_event` line from Claude's `--include-partial-messages` output.
+ *
+ * Only the two deltas that carry displayable text become messages; every
+ * lifecycle event (`message_start`, `content_block_start`, `content_block_stop`,
+ * `message_delta`, `message_stop`) is structural and yields `null`.
+ *
+ * `signature_delta` is the thinking block's cryptographic signature, not prose,
+ * and `input_json_delta` is a fragment of a tool's JSON input — the finished
+ * `assistant` message carries that input whole, so both are dropped here.
+ */
+function parseStreamEvent(
+  raw: Record<string, unknown>,
+): StreamMessage | null {
+  const event = raw.event as Record<string, unknown> | undefined;
+  if (!event || event.type !== "content_block_delta") return null;
+
+  const delta = event.delta as Record<string, unknown> | undefined;
+  if (!delta) return null;
+
+  if (delta.type === "text_delta") {
+    const text = delta.text;
+    if (typeof text !== "string" || text.length === 0) return null;
+    return { type: "assistant", content: text };
+  }
+
+  if (delta.type === "thinking_delta") {
+    const thinking = delta.thinking;
+    if (typeof thinking !== "string" || thinking.length === 0) return null;
+    return { type: "assistant", subtype: "thinking", content: thinking };
+  }
+
+  return null;
+}
+
 function parseStreamMessageInner(
   raw: Record<string, unknown>,
   type: string | undefined,
+  options: ParseStreamMessageOptions,
 ): StreamMessage | null {
   switch (type) {
+    // Gated on the mode, not merely parsed when present: a parser that read
+    // deltas *and* finished blocks would emit every sentence twice. Each mode
+    // must be self-consistent even if fed the other mode's output.
+    case "stream_event":
+      return options.partialMessages ? parseStreamEvent(raw) : null;
+
     case "assistant": {
       const subtype = raw.subtype as string | undefined;
       if (subtype === "thinking") {
@@ -147,9 +208,13 @@ function parseStreamMessageInner(
       }
       const blocks = (Array.isArray(msg?.content) ? msg.content : []) as ContentBlock[];
 
-      const thinkingTexts = blocks
-        .filter((b) => b.type === "thinking" && b.text)
-        .map((b) => b.text as string);
+      // In partial-message mode the deltas already delivered these two block
+      // kinds; re-emitting them here is what would double every sentence.
+      const thinkingTexts = options.partialMessages
+        ? []
+        : blocks
+            .filter((b) => b.type === "thinking" && b.text)
+            .map((b) => b.text as string);
       if (thinkingTexts.length > 0) {
         return {
           type: "assistant",
@@ -158,9 +223,11 @@ function parseStreamMessageInner(
         };
       }
 
-      const texts = blocks
-        .filter((b) => b.type === "text" && b.text)
-        .map((b) => b.text as string);
+      const texts = options.partialMessages
+        ? []
+        : blocks
+            .filter((b) => b.type === "text" && b.text)
+            .map((b) => b.text as string);
 
       const toolUses = blocks.filter((b) => b.type === "tool_use");
 


### PR DESCRIPTION
Closes #42

## やったこと

Claude アダプタが `--include-partial-messages` を使ってトークン単位で流せるようにした。**型と消費側は元から差分前提**（`AssistantMessage` = "a plain assistant body delta"、`isAssistantBody()` で連結）で、欠けていたのは Claude アダプタだけだった。

| 変更 | 内容 |
|---|---|
| `stream-parser.ts` | `stream_event` の `text_delta` / `thinking_delta` を差分メッセージへ。lifecycle と `signature_delta` / `input_json_delta` は `null` |
| `adapters/claude.ts` | `options.stream` で `--include-partial-messages` を付与。`createClaudeAdapter()` ファクトリを追加 |
| `core/cli-adapter.ts` | `SessionOptions.stream` の JSDoc を更新（Ollama 限定ではなくなった） |

## 二重配信への対処

**CLI は差分に加えて完成 `assistant` メッセージも emit する。** 実測で確認:

```
  6  stream_event/content_block_delta/thinking_delta
  5  stream_event/content_block_delta/text_delta
  2  assistant                                        ← 完成側も届く
```

素通しすると**同じ文が 2 回出る**。実際、門番を入れる前の実測では本文が **302 字 = 151 字ちょうど 2 倍**になった。

対処は 2 つ:

1. **partial モードでは完成 `assistant` の `text` / `thinking` を落とす**（`tool_use` は通す）
2. **既定モードでは `stream_event` を丸ごと無視する**

結果、**どちらのモードも相手のイベントを無視する**ので、片方の出力を他方に食わせても二重にならない。実測でも両モードとも 151 字で一致。

`tool_use` を完成側から取るのは、tool 入力が `input_json_delta` の断片として届くため。部分 JSON を組み立てるより一度に読む方が壊れにくい。

## なぜファクトリか

`parseOutput(line)` は行しか受け取らないが、**1 つのアダプタが複数セッションで共有されうる**ためモジュール状態にモードを置けない。`createClaudeAdapter({ stream })` でインスタンスに閉じ込めた。`claudeAdapter`（既存 const）は既定モードのまま不変。

## 検証

- `packages/server` 168 tests / `packages/core` 8 tests green
- `typecheck` / `lint` / `build` green
- **実 CLI 出力での end-to-end 確認** — `claude 2.1.212` を `--include-partial-messages` 付きで走らせた生ログを両モードのアダプタに通し、本文が一致し二重化しないことを確認
- テストの fixture も同じ生ログから採取（手書きの近似では「完成メッセージも届く」ことを捉えられなかった）

`packages/react` の 56 件失敗は `React.act is not a function` という**既存の環境起因**で、`origin/main` の素のチェックアウトでも同様に再現する。本 PR の差分（`core` / `server` のみ）とは無関係。

## ⚠️ 挙動の変化（レビュー時に確認してほしい点）

**partial モードでは thinking 本文が新たに表示される。**

既存パーサは完成メッセージの thinking を `b.type === "thinking" && b.text` で拾おうとしているが、**Claude が実際に送るのは `thinking:` フィールド**（`{"type":"thinking","thinking":"…","signature":"…"}`）。そのため `.text` は常に undefined で、**Claude の thinking 本文はこれまで一度も表示されていなかった**。

partial モードでは `thinking_delta` から拾うので、有効にすると thinking が出るようになる。これは望ましい方向だと考えるが、**既定モードの取りこぼしは本 PR では直していない**（既定の挙動を変えるとレビュー範囲が広がるため）。別 issue にする価値がある。