### PR TITLE
feat(claude): conversation_reset を system メッセージとして通す

### DIFF
--- a/.changeset/conversation-reset.md
+++ b/.changeset/conversation-reset.md
@@ -1,0 +1,14 @@
+---
+"@synapse-chat/server": minor
+---
+
+feat(claude): surface `conversation_reset` as a `system` message
+
+`/clear` emits a `conversation_reset` line carrying only ids and a timestamp.
+It used to be dropped, which was harmless while the CLI still followed it with a
+synthetic `"(no content)"` assistant message — the trace consumers actually
+rendered. The CLI stopped emitting that, leaving `/clear` silent.
+
+It now parses to `{ type: "system", subtype: "conversation-reset" }`. Whether
+that draws anything is the app's call: consumers whitelist the `system` subtypes
+they can render, so nothing changes for one that does not list it.

--- a/packages/server/src/stream-parser.ts
+++ b/packages/server/src/stream-parser.ts
@@ -429,6 +429,15 @@ function parseStreamMessageInner(
 
     // Claude CLI emits rate_limit_event on stdout during rate limiting.
     // Drop these — retry logic lives at the process-manager layer.
+    // `/clear`. The payload carries only ids and a timestamp — there is no text
+    // to show — so this is surfaced as an open `system` variant and the app
+    // decides whether it is worth drawing. Previously the CLI followed the
+    // reset with a synthetic `"(no content)"` assistant message, which is what
+    // consumers had been treating as the visible trace of a clear; it no longer
+    // does, leaving `/clear` completely silent.
+    case "conversation_reset":
+      return { type: "system", subtype: "conversation-reset", content: "" };
+
     case "rate_limit_event":
     case "error":
       return null;

--- a/packages/server/src/synthetic-passthrough.test.ts
+++ b/packages/server/src/synthetic-passthrough.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createStreamMessageParser } from "./stream-parser.js";
+import { parseStreamMessage, createStreamMessageParser } from "./stream-parser.js";
 
 /**
  * Fixtures captured from `claude 2.1.212`. The `/clear` shape in particular is
@@ -99,5 +99,32 @@ describe("#44 インスタンスは独立", () => {
     a.call(null, textDelta("x"));
     // b は差分を見ていないので、完成側を捨ててはいけない
     expect(b(finishedText("そのまま"))).toMatchObject({ content: "そのまま" });
+  });
+});
+
+describe("#46 conversation_reset", () => {
+  /** Verbatim from `claude 2.1.212` — ids and a timestamp, no text. */
+  const reset = {
+    type: "conversation_reset",
+    new_conversation_id: "dc9494eb-60a4-4e6c-bcc1-2c5277841a11",
+    session_id: "3878f0aa-8fd6-4df5-9b40-8535ae295d26",
+    uuid: "850570dd-8d91-441e-af31-028d664c5108",
+    timestamp: 1787785152666,
+  };
+
+  it("通す（消費側が描くかどうかは別の判断）", () => {
+    expect(parseStreamMessage(reset)).toMatchObject({
+      type: "system",
+      subtype: "conversation-reset",
+    });
+  });
+
+  it("partial モードでも通る", () => {
+    const parse = createStreamMessageParser({ partialMessages: true });
+    expect(parse(reset)).toMatchObject({ type: "system", subtype: "conversation-reset" });
+  });
+
+  it("本文は持たない（ラベルは消費側が subtype から引く）", () => {
+    expect((parseStreamMessage(reset) as { content?: string })?.content).toBe("");
   });
 });


### PR DESCRIPTION
Closes #46

## 背景

`/clear` が emit する `conversation_reset` を既定分岐で捨てていた。CLI が続けて**合成 assistant**（`"(no content)"`）を出していた間はそれが「何か起きた」の唯一の痕跡だったが、**CLI がそれを出さなくなり `/clear` が完全に無音**になった。

実測したペイロード:

```jsonc
{ "type": "conversation_reset", "new_conversation_id": "…", "session_id": "…", "uuid": "…", "timestamp": 1787785152666 }
```

**表示できるテキストは持たない。** 「起きた」という事実だけ。

## 修正

開いた `SystemMessage` 変種として通す:

```ts
case "conversation_reset":
  return { type: "system", subtype: "conversation-reset", content: "" };
```

`content` を空にするのは、この型に載せられる本文が存在しないため。**ラベルは消費側が subtype から引く。**

**本 PR 単体では挙動が変わらない。** 消費側は描画できる `system` subtype をホワイトリストで持つので、登録しないアプリでは従来どおり無視される。通すかどうかはアプリの判断、という切り分け。

## 検証

- `packages/server` **178 tests green**（新規 3 件：通ること / partial モードでも通ること / 本文が空であること）
- fixture は実 CLI のペイロードそのまま
- `typecheck` / `lint` green